### PR TITLE
update api endpoints to /start and /test

### DIFF
--- a/cmd/test_cmd.go
+++ b/cmd/test_cmd.go
@@ -125,7 +125,7 @@ func doStart(url string) (*enclave, error) {
 		return nil, err
 	}
 
-	req, err := http.NewRequest("POST", url+"/v1/begin", bytes.NewBuffer(body))
+	req, err := http.NewRequest("POST", url+"/v1/start", bytes.NewBuffer(body))
 	if err != nil {
 		return nil, fmt.Errorf("unable to create request %s", err)
 	}
@@ -170,7 +170,7 @@ func doTest(url string, id id.ID, functionData []byte, functionSecret []byte, se
 		return "", err
 	}
 
-	endpoint := fmt.Sprintf("%s/v1/run/%s", url, id)
+	endpoint := fmt.Sprintf("%s/v1/test/%s", url, id)
 	req, err := http.NewRequest("POST", endpoint, bytes.NewBuffer(body))
 	if err != nil {
 		return "", err

--- a/go.mod
+++ b/go.mod
@@ -3,14 +3,14 @@ module github.com/capeprivacy/cli
 go 1.18
 
 require (
+	github.com/capeprivacy/go-kit v0.0.0-20220420152147-667383169b7a
+	github.com/fxamacker/cbor/v2 v2.4.0
 	github.com/google/tink/go v1.6.1
 	github.com/spf13/cobra v1.4.0
 )
 
 require (
-	github.com/capeprivacy/go-kit v0.0.0-20220420152147-667383169b7a // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
-	github.com/fxamacker/cbor/v2 v2.4.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
@@ -18,7 +18,6 @@ require (
 	github.com/mitchellh/mapstructure v1.4.3 // indirect
 	github.com/pelletier/go-toml v1.9.4 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.0-beta.8 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/spf13/afero v1.8.2 // indirect
 	github.com/spf13/cast v1.4.1 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
@@ -38,5 +37,5 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.11.0
 	github.com/veraison/go-cose v0.0.0-sign1-alpha.0.0.20220425074922-8cef769ef52c
-	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4
+	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,6 @@ github.com/fsnotify/fsnotify v1.5.1 h1:mZcQUHVQUQWoPXXtuf9yuEXKudkV2sx1E06UadKWp
 github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
 github.com/fxamacker/cbor v1.5.1 h1:XjQWBgdmQyqimslUh5r4tUGmoqzHmBFQOImkWGi2awg=
 github.com/fxamacker/cbor v1.5.1/go.mod h1:3aPGItF174ni7dDzd6JZ206H8cmr4GDNBGpPa971zsU=
-github.com/fxamacker/cbor/v2 v2.2.1-0.20200429214022-fc263b46c618 h1:RIQZGQ00xy1acO7H7mjL8N5ZDyI0soZG7X8akiXwSTo=
-github.com/fxamacker/cbor/v2 v2.2.1-0.20200429214022-fc263b46c618/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
 github.com/fxamacker/cbor/v2 v2.4.0 h1:ri0ArlOR+5XunOP8CRUowT0pSJOwhW098ZCUyskZD88=
 github.com/fxamacker/cbor/v2 v2.4.0/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
@@ -199,7 +197,6 @@ github.com/pelletier/go-toml v1.9.4/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCko
 github.com/pelletier/go-toml/v2 v2.0.0-beta.8 h1:dy81yyLYJDwMTifq24Oi/IslOslRrDSb3jwDggjz3Z0=
 github.com/pelletier/go-toml/v2 v2.0.0-beta.8/go.mod h1:r9LEWfGN8R5k0VXJ+0BkIe7MYkRdwZOjgMj2KwnJFUo=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qRg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -233,8 +230,6 @@ github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMT
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
-github.com/veraison/go-cose v0.0.0-sign1-alpha.0 h1:h/gUq6+EDSc5Q37Av2bIgFjzZ6FFbGrt29mpcRzud3M=
-github.com/veraison/go-cose v0.0.0-sign1-alpha.0/go.mod h1:EfKgT9pkBoSw4KJuyKpFK6b2fbQn/+jdkN2p3wqoRAs=
 github.com/veraison/go-cose v0.0.0-sign1-alpha.0.0.20220425074922-8cef769ef52c h1:fDBWa4T8pYTyX9OmzM9sahOuc8jwsU9IVUkrwyoHW6s=
 github.com/veraison/go-cose v0.0.0-sign1-alpha.0.0.20220425074922-8cef769ef52c/go.mod h1:7ziE85vSq4ScFTg6wyoMXjucIGOf4JkFEZi/an96Ct4=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=


### PR DESCRIPTION
The naming was already updated. This has to be merged with
https://github.com/capeprivacy/enclave-server/pull/9