### PR TITLE
pass in a local dir and filename for tuner

### DIFF
--- a/cmd/cape/cmd/deploy.go
+++ b/cmd/cape/cmd/deploy.go
@@ -79,7 +79,7 @@ func deploy(cmd *cobra.Command, args []string) error {
 		name = n
 	}
 
-	dID, err := Deploy(u, name, functionInput, insecure)
+	dID, err := Deploy(u, name, functionInput, insecure, C.LocalAuthDir, C.LocalAuthFileName)
 	if err != nil {
 		return err
 	}
@@ -89,7 +89,7 @@ func deploy(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func Deploy(url string, functionInput string, functionName string, insecure bool) (string, error) {
+func Deploy(url string, functionInput string, functionName string, insecure bool, dir string, filename string) (string, error) {
 	file, err := os.Open(functionInput)
 	if err != nil {
 		return "", fmt.Errorf("unable to read function directory or file: %w", err)
@@ -149,7 +149,7 @@ func Deploy(url string, functionInput string, functionName string, insecure bool
 		reader = buf
 	}
 
-	id, err := doDeploy(url, functionName, reader, insecure)
+	id, err := doDeploy(url, functionName, reader, insecure, dir, filename)
 	if err != nil {
 		return "", fmt.Errorf("unable to deploy function: %w", err)
 	}
@@ -157,7 +157,7 @@ func Deploy(url string, functionInput string, functionName string, insecure bool
 	return id, nil
 }
 
-func doDeploy(url string, name string, reader io.Reader, insecure bool) (string, error) {
+func doDeploy(url string, name string, reader io.Reader, insecure bool, dir string, filename string) (string, error) {
 	endpoint := fmt.Sprintf("%s/v1/deploy", url)
 	s := spinner.New(spinner.CharSets[26], 300*time.Millisecond)
 	defer s.Stop()
@@ -183,7 +183,7 @@ func doDeploy(url string, name string, reader io.Reader, insecure bool) (string,
 		return "", err
 	}
 
-	token, err := getAuthToken()
+	token, err := getAuthToken(dir, filename)
 	if err != nil {
 		return "", err
 	}
@@ -257,8 +257,8 @@ func getNonce() (string, error) {
 	return base64.StdEncoding.EncodeToString(buf), nil
 }
 
-func getAuthToken() (string, error) {
-	tokenResponse, err := getTokenResponse()
+func getAuthToken(dir string, filename string) (string, error) {
+	tokenResponse, err := getTokenResponse(dir, filename)
 	if err != nil {
 		return "", fmt.Errorf("failed to get auth token (did you run 'cape login'?): %v", err)
 	}

--- a/cmd/cape/cmd/identity.go
+++ b/cmd/cape/cmd/identity.go
@@ -25,7 +25,7 @@ func init() {
 }
 
 func identity(cmd *cobra.Command, args []string) error {
-	tokenResponse, err := getTokenResponse()
+	tokenResponse, err := getTokenResponse(C.LocalAuthDir, C.LocalAuthFileName)
 	if err != nil {
 		return err
 	}
@@ -38,8 +38,8 @@ func identity(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func getTokenResponse() (*TokenResponse, error) {
-	authFile, err := os.Open(filepath.Join(C.LocalAuthDir, C.LocalAuthFileName))
+func getTokenResponse(dir string, filename string) (*TokenResponse, error) {
+	authFile, err := os.Open(filepath.Join(dir, filename))
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/cape/cmd/run.go
+++ b/cmd/cape/cmd/run.go
@@ -70,16 +70,16 @@ func run(cmd *cobra.Command, args []string) error {
 	functionID := args[0]
 	dataFile := args[1]
 
-	return Run(u, dataFile, functionID, insecure)
+	return Run(u, dataFile, functionID, insecure, C.LocalAuthDir, C.LocalAuthFileName)
 }
 
-func Run(u string, dataFile string, functionID string, insecure bool) error {
+func Run(u string, dataFile string, functionID string, insecure bool, dir string, filename string) error {
 	inputData, err := ioutil.ReadFile(dataFile)
 	if err != nil {
 		return fmt.Errorf("unable to read data file: %w", err)
 	}
 
-	results, err := doRun(u, functionID, inputData, insecure)
+	results, err := doRun(u, functionID, inputData, insecure, dir, filename)
 	if err != nil {
 		return fmt.Errorf("error processing data: %w", err)
 	}
@@ -89,7 +89,7 @@ func Run(u string, dataFile string, functionID string, insecure bool) error {
 	return nil
 }
 
-func doRun(url string, functionID string, data []byte, insecure bool) ([]byte, error) {
+func doRun(url string, functionID string, data []byte, insecure bool, dir string, filename string) ([]byte, error) {
 	endpoint := fmt.Sprintf("%s/v1/run/%s", url, functionID)
 
 	c, res, err := websocketDial(endpoint, insecure)
@@ -103,7 +103,7 @@ func doRun(url string, functionID string, data []byte, insecure bool) ([]byte, e
 		return nil, err
 	}
 
-	token, err := getAuthToken()
+	token, err := getAuthToken(dir, filename)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- i'm going to create a local auth file in tuner service to be able to test `cape deploy` and `cape run`
- this file will be used and passed into CLI's `Deploy` and `Run` and into `getAuthToken` which passes `dir` and `filename` into `getTokenResponse`