### PR TITLE
Couple of goreleaser adjustments

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -19,11 +19,12 @@ builds:
       - arm64
     binary: cape
 archives:
-  - replacements:
+  - name_template: "{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    files: [] # don't include any additional files
+    replacements:
       darwin: Darwin
       linux: Linux
       windows: Windows
-      386: i386
       amd64: x86_64
 checksum:
   name_template: 'checksums.txt'


### PR DESCRIPTION
- Don't include any extra files in the tar. It now only contains the
  binary
- Change the tar name template to use Binary name (cape) instead of
  ProjectName (cli).