### PR TITLE
Goreleaser was still including files

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -20,7 +20,8 @@ builds:
     binary: cape
 archives:
   - name_template: "{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
-    files: [] # don't include any additional files
+    files:
+      - none*
     replacements:
       darwin: Darwin
       linux: Linux


### PR DESCRIPTION
Need to use this hack to disable including any files see
https://goreleaser.com/customization/archive/#packaging-only-the-binaries