### PR TITLE
add verbose logging for cape test

### DIFF
--- a/cmd/cape/cmd/test.go
+++ b/cmd/cape/cmd/test.go
@@ -30,6 +30,8 @@ func init() {
 }
 
 func Test(cmd *cobra.Command, args []string) error {
+	// Set test to be in verbose mode by default.
+	log.SetLevel(log.DebugLevel)
 	u := C.EnclaveHost
 	insecure := C.Insecure
 


### PR DESCRIPTION
For https://capeprivacy.atlassian.net/browse/CAPE-644 

Outputs verbose logging during execution of test. Subsequent calls will not respect the debug setting. 