### PR TITLE
Add --key-policy-hash and --function-hash flags to run

### DIFF
--- a/attest/attest.go
+++ b/attest/attest.go
@@ -40,7 +40,7 @@ type AttestationDoc struct {
 }
 
 type AttestationUserData struct {
-	FuncHash []byte `json:"func_hash"`
+	FuncHash      []byte `json:"func_hash"`
 	KeyPolicyHash []byte `json:"key_policy_hash"`
 }
 

--- a/cmd/cape/cmd/run.go
+++ b/cmd/cape/cmd/run.go
@@ -54,6 +54,8 @@ func init() {
 
 	runCmd.PersistentFlags().StringP("token", "t", "", "token to use")
 	runCmd.PersistentFlags().StringP("file", "f", "", "input data file")
+	runCmd.PersistentFlags().StringP("function-hash", "", "", "function hash to attest")
+	runCmd.PersistentFlags().StringP("key-policy-hash", "", "", "key policy hash to attest")
 }
 
 func run(cmd *cobra.Command, args []string) error {
@@ -66,12 +68,30 @@ func run(cmd *cobra.Command, args []string) error {
 
 	functionID := args[0]
 
-	var funcHash []byte
-
 	var input []byte
 	file, err := cmd.Flags().GetString("file")
 	if err != nil {
 		return fmt.Errorf("error retrieving file flag")
+	}
+
+	funcHashArg, err := cmd.Flags().GetString("function-hash")
+	if err != nil {
+		return fmt.Errorf("error retrieving function_hash flag")
+	}
+
+	funcHash, err := hex.DecodeString(funcHashArg)
+	if err != nil {
+		return fmt.Errorf("error reading function hash")
+	}
+
+	keyPolicyHashArg, err := cmd.Flags().GetString("key-policy-hash")
+	if err != nil {
+		return fmt.Errorf("error retrieving key_policy_hash flag")
+	}
+
+	keyPolicyHash, err := hex.DecodeString(keyPolicyHashArg)
+	if err != nil {
+		return fmt.Errorf("error reading key policy hash")
 	}
 
 	switch {
@@ -84,12 +104,6 @@ func run(cmd *cobra.Command, args []string) error {
 	case len(args) == 2:
 		// read input from  command line string
 		input = []byte(args[1])
-	case len(args) == 3:
-		input = []byte(args[1])
-		funcHash, err = hex.DecodeString(args[2])
-		if err != nil {
-			return fmt.Errorf("error reading function hash")
-		}
 
 	default:
 		// read input from stdin
@@ -100,7 +114,7 @@ func run(cmd *cobra.Command, args []string) error {
 		input = buf.Bytes()
 	}
 
-	results, err := doRun(u, functionID, input, insecure, funcHash)
+	results, err := doRun(u, functionID, input, insecure, funcHash, keyPolicyHash)
 	if err != nil {
 		return fmt.Errorf("error processing data: %w", err)
 	}
@@ -116,7 +130,7 @@ func Run(url string, functionID string, file string, insecure bool) error {
 		return fmt.Errorf("unable to read data file: %w", err)
 	}
 	// TODO: Tuner may want to verify function hash later.
-	_, err = doRun(url, functionID, input, insecure, nil)
+	_, err = doRun(url, functionID, input, insecure, nil, nil)
 	if err != nil {
 		return fmt.Errorf("error processing data: %w", err)
 	}
@@ -124,7 +138,7 @@ func Run(url string, functionID string, file string, insecure bool) error {
 	return nil
 }
 
-func doRun(url string, functionID string, data []byte, insecure bool, funcHash []byte) ([]byte, error) {
+func doRun(url string, functionID string, data []byte, insecure bool, funcHash []byte, keyPolicyHash []byte) ([]byte, error) {
 	endpoint := fmt.Sprintf("%s/v1/run/%s", url, functionID)
 
 	c, res, err := websocketDial(endpoint, insecure)
@@ -183,13 +197,21 @@ func doRun(url string, functionID string, data []byte, insecure bool, funcHash [
 		return nil, err
 	}
 
-	if userData == nil && funcHash != nil {
+	if userData.FuncHash == nil && len(funcHash) > 0 {
 		return nil, fmt.Errorf("did not receive function hash from enclave")
 	}
 
 	// If function hash as an optional parameter has not been specified by the user, then we don't check the value.
-	if funcHash != nil && !reflect.DeepEqual(funcHash, userData.FuncHash) {
+	if len(funcHash) > 0 && !reflect.DeepEqual(funcHash, userData.FuncHash) {
 		return nil, fmt.Errorf("returned function hash did not match provided, got: %x, want %x", userData.FuncHash, funcHash)
+	}
+
+	if userData.KeyPolicyHash == nil && len(keyPolicyHash) > 0 {
+		return nil, fmt.Errorf("did not receive key policy hash from enclave")
+	}
+
+	if len(keyPolicyHash) > 0 && !reflect.DeepEqual(keyPolicyHash, userData.KeyPolicyHash) {
+		return nil, fmt.Errorf("returned key policy hash did not match provided, got: %x, want %x", userData.KeyPolicyHash, keyPolicyHash)
 	}
 
 	encryptedData, err := crypto.LocalEncrypt(*doc, data)


### PR DESCRIPTION
You can now check the key policy hash and the function hash by passing flags into cape run.

Example:
```
cape run 46XyUZ8fjNnsHvsVFXcTAJ 5 --key-policy-hash 565e93d4b8dfd4a25c20f8d19b905232199520d01627462c161394ec1f6eecbf --function-hash cbca8c9f7ac41138935018c3f45cd16d1abfbe15a37b1fc09a11dfbc3d44b447
```