### PR TITLE
Return http.Response when websocket dial fails

### DIFF
--- a/capetest/capetest.go
+++ b/capetest/capetest.go
@@ -44,7 +44,7 @@ func websocketDial(url string, insecure bool) (*websocket.Conn, *http.Response, 
 	log.Debug(str)
 	c, r, err := websocket.DefaultDialer.Dial(url, nil)
 	if err != nil {
-		return nil, nil, err
+		return nil, r, err
 	}
 
 	log.Debugf("* Websocket connection established")

--- a/cmd/cape/cmd/deploy.go
+++ b/cmd/cape/cmd/deploy.go
@@ -316,7 +316,7 @@ func websocketDial(url string, insecure bool) (*websocket.Conn, *http.Response, 
 	log.Debug(str)
 	c, r, err := websocket.DefaultDialer.Dial(url, nil)
 	if err != nil {
-		return nil, nil, err
+		return nil, r, err
 	}
 
 	log.Debugf("* Websocket connection established")


### PR DESCRIPTION
Returns the http.Response object returned by gorrilla's websocket dial
if the dial call fails. Previously we were returning only the error,
which meant that our callers couldn't get any information about the root
cause that might be provided in the http response.
