### PR TITLE
CAPE-873 | refactor CLI to include go SDK

### DIFF
--- a/cmd/cape/cmd/deploy.go
+++ b/cmd/cape/cmd/deploy.go
@@ -4,35 +4,20 @@ import (
 	"archive/zip"
 	"bytes"
 	"crypto/rsa"
-	"crypto/sha256"
-	"crypto/tls"
 	"crypto/x509"
-	"encoding/json"
 	"encoding/pem"
 	"errors"
 	"fmt"
 	"io"
-	"net/http"
 	"os"
 	"path/filepath"
 
-	"github.com/gorilla/websocket"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
-	"github.com/capeprivacy/cli/entities"
-	"github.com/capeprivacy/cli/protocol"
-
-	"github.com/capeprivacy/cli/attest"
-
-	"github.com/capeprivacy/cli/crypto"
-
+	"github.com/capeprivacy/cli/sdk"
 	czip "github.com/capeprivacy/cli/zip"
 )
-
-type ErrorMsg struct {
-	Error string `json:"error"`
-}
 
 type PublicKeyRequest struct {
 	FunctionTokenPublicKey string `json:"function_token_pk"`
@@ -184,7 +169,20 @@ func doDeploy(url string, functionInput string, functionName string, insecure bo
 		return "", nil, err
 	}
 
-	id, hash, err := Deploy(url, token, functionName, reader, insecure, pcrSlice)
+	functionTokenPublicKey, err := getFunctionTokenPublicKey()
+	if err != nil {
+		return "", nil, err
+	}
+
+	id, hash, err := sdk.Deploy(sdk.DeployRequest{
+		Url:                    url,
+		Token:                  token,
+		Name:                   functionName,
+		Reader:                 reader,
+		Insecure:               insecure,
+		PcrSlice:               pcrSlice,
+		FunctionTokenPublicKey: functionTokenPublicKey,
+	})
 	if err != nil {
 		return "", nil, fmt.Errorf("unable to deploy function: %w", err)
 	}
@@ -214,148 +212,6 @@ func zipSize(path string) (uint64, error) {
 	}
 
 	return size, nil
-}
-
-func Deploy(url string, token string, name string, reader io.Reader, insecure bool, pcrSlice []string) (string, []byte, error) {
-	endpoint := fmt.Sprintf("%s/v1/deploy", url)
-
-	log.Info("Deploying function to Cape ...")
-
-	conn, res, err := websocketDial(endpoint, insecure, token)
-	if err != nil {
-		log.Error("error dialing websocket: ", err)
-		// This check is necessary because we don't necessarily return an http response from sentinel.
-		// Http error code and message is returned if network routing fails.
-		if res != nil {
-			var e ErrorMsg
-			if err := json.NewDecoder(res.Body).Decode(&e); err != nil {
-				return "", nil, err
-			}
-			res.Body.Close()
-			return "", nil, fmt.Errorf("error code: %d, reason: %s", res.StatusCode, e.Error)
-		}
-		return "", nil, err
-	}
-	defer conn.Close()
-
-	p := protocol.Protocol{Websocket: conn}
-
-	nonce, err := crypto.GetNonce()
-	if err != nil {
-		return "", nil, err
-	}
-
-	functionTokenPublicKey, err := getFunctionTokenPublicKey()
-	if err != nil {
-		return "", nil, err
-	}
-
-	req := entities.StartRequest{Nonce: []byte(nonce), AuthToken: token}
-	log.Debug("\n> Sending Nonce and Auth Token")
-	if err := p.WriteStart(req); err != nil {
-		log.Error("error writing deploy request")
-		return "", nil, err
-	}
-
-	log.Debug("* Waiting for attestation document...")
-
-	attestDoc, err := p.ReadAttestationDoc()
-	if err != nil {
-		log.Error("error reading attestation doc")
-		return "", nil, err
-	}
-
-	log.Debug("< Downloading AWS Root Certificate")
-	rootCert, err := attest.GetRootAWSCert()
-	if err != nil {
-		return "", nil, err
-	}
-
-	log.Debug("< Attestation document")
-	doc, _, err := attest.Attest(attestDoc, rootCert)
-	if err != nil {
-		log.Error("error attesting")
-		return "", nil, err
-	}
-
-	hasher := sha256.New()
-	// tReader is used to stream data to the hasher function.
-	tReader := io.TeeReader(reader, hasher)
-	plaintext, err := io.ReadAll(tReader)
-	if err != nil {
-		log.Error("error reading plaintext function")
-		return "", nil, err
-	}
-
-	// Print out the hash to the user.
-	hash := hasher.Sum(nil)
-	ciphertext, err := crypto.LocalEncrypt(*doc, plaintext)
-	if err != nil {
-		log.Error("error encrypting function")
-		return "", nil, err
-	}
-
-	log.Debug("\n> Sending Public Key")
-	if err := p.WriteFunctionPublicKey(functionTokenPublicKey); err != nil {
-		log.Error("error sending public key")
-		return "", nil, err
-	}
-
-	log.Debug("\n> Deploying Encrypted Function")
-	err = writeFunction(conn, bytes.NewBuffer(ciphertext))
-	if err != nil {
-		return "", nil, err
-	}
-
-	log.Debug("* Waiting for deploy response...")
-
-	resData, err := p.ReadDeploymentResults()
-	if err != nil {
-		return "", nil, err
-	}
-	log.Debugf("< Received Deploy Response %v", resData)
-
-	return resData.ID, hash, nil
-}
-
-func websocketDial(url string, insecure bool, authToken string) (*websocket.Conn, *http.Response, error) {
-	if insecure {
-		websocket.DefaultDialer.TLSClientConfig = &tls.Config{
-			InsecureSkipVerify: true,
-		}
-	}
-
-	str := fmt.Sprintf("* Dialing %s", url)
-	if insecure {
-		str += " (insecure)"
-	}
-
-	secWebsocketProtocol := http.Header{"Sec-Websocket-Protocol": []string{"cape.runtime", authToken}}
-
-	log.Debug(str)
-	c, r, err := websocket.DefaultDialer.Dial(url, secWebsocketProtocol)
-	if err != nil {
-		return nil, r, err
-	}
-
-	log.Debugf("* Websocket connection established")
-	return c, r, nil
-}
-
-func writeFunction(conn *websocket.Conn, reader io.Reader) error {
-	writer, err := conn.NextWriter(websocket.BinaryMessage)
-	if err != nil {
-		log.Errorf("error getting writer for function: %v", err)
-		return err
-	}
-	defer writer.Close()
-
-	_, err = io.Copy(writer, reader)
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
 func getAuthToken() (string, error) {

--- a/cmd/cape/cmd/deploy.go
+++ b/cmd/cape/cmd/deploy.go
@@ -8,6 +8,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"github.com/capeprivacy/cli/entities"
 	"io"
 	"os"
 	"path/filepath"
@@ -193,7 +194,7 @@ func doDeploy(url string, functionInput string, functionName string, authType en
 		Insecure:               insecure,
 		PcrSlice:               pcrSlice,
 		FunctionTokenPublicKey: functionTokenPublicKey,
-		AuthType: authType,
+		AuthType:               authType,
 	})
 	if err != nil {
 		return "", nil, fmt.Errorf("unable to deploy function: %w", err)

--- a/cmd/cape/cmd/deploy.go
+++ b/cmd/cape/cmd/deploy.go
@@ -8,7 +8,6 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"github.com/capeprivacy/cli/entities"
 	"io"
 	"os"
 	"path/filepath"
@@ -16,6 +15,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/capeprivacy/cli/entities"
 	"github.com/capeprivacy/cli/sdk"
 	czip "github.com/capeprivacy/cli/zip"
 )

--- a/cmd/cape/cmd/deploy.go
+++ b/cmd/cape/cmd/deploy.go
@@ -188,13 +188,15 @@ func doDeploy(url string, functionInput string, functionName string, authType en
 
 	id, hash, err := sdk.Deploy(sdk.DeployRequest{
 		Url:                    url,
-		Token:                  token,
 		Name:                   functionName,
 		Reader:                 reader,
 		Insecure:               insecure,
 		PcrSlice:               pcrSlice,
 		FunctionTokenPublicKey: functionTokenPublicKey,
-		AuthType:               authType,
+		FunctionAuth: entities.FunctionAuth{
+			Type:  authType,
+			Token: token,
+		},
 	})
 	if err != nil {
 		return "", nil, fmt.Errorf("unable to deploy function: %w", err)

--- a/cmd/cape/cmd/deploy.go
+++ b/cmd/cape/cmd/deploy.go
@@ -175,7 +175,7 @@ func doDeploy(url string, functionInput string, functionName string, insecure bo
 	}
 
 	id, hash, err := sdk.Deploy(sdk.DeployRequest{
-		Url:                    url,
+		URL:                    url,
 		Name:                   functionName,
 		Reader:                 reader,
 		Insecure:               insecure,

--- a/cmd/cape/cmd/deploy.go
+++ b/cmd/cape/cmd/deploy.go
@@ -15,7 +15,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
-	"github.com/capeprivacy/cli/entities"
 	"github.com/capeprivacy/cli/sdk"
 	czip "github.com/capeprivacy/cli/zip"
 )
@@ -182,9 +181,7 @@ func doDeploy(url string, functionInput string, functionName string, insecure bo
 		Insecure:               insecure,
 		PcrSlice:               pcrSlice,
 		FunctionTokenPublicKey: functionTokenPublicKey,
-		FunctionAuth: entities.FunctionAuth{
-			Token: token,
-		},
+		AuthToken:              token,
 	})
 	if err != nil {
 		return "", nil, fmt.Errorf("unable to deploy function: %w", err)

--- a/cmd/cape/cmd/run.go
+++ b/cmd/cape/cmd/run.go
@@ -153,7 +153,7 @@ func run(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// This function is exported for tuner to use.
+// TODO: This function is exported for tuner to use. Remove once tuner is using sdk.Run directly
 func Run(url string, auth entities.FunctionAuth, functionID string, file string, insecure bool) ([]byte, error) {
 	input, err := os.ReadFile(file)
 	if err != nil {

--- a/cmd/cape/cmd/run.go
+++ b/cmd/cape/cmd/run.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
+	"github.com/capeprivacy/cli/entities"
 	"io"
 	"os"
 
@@ -119,7 +120,7 @@ func run(cmd *cobra.Command, args []string) error {
 		input = buf.Bytes()
 	}
 
-	token, err := getAuthToken()
+	t, err := getAuthToken()
 	if err != nil {
 		return err
 	}
@@ -137,8 +138,7 @@ func run(cmd *cobra.Command, args []string) error {
 		FuncHash:      funcHash,
 		KeyPolicyHash: keyPolicyHash,
 		PcrSlice:      pcrSlice,
-		FunctionAuth:     auth,
-		FunctionToken: functionToken,
+		FunctionAuth:  auth,
 	})
 	if err != nil {
 		return fmt.Errorf("error processing data: %w", err)
@@ -155,11 +155,6 @@ func Run(url string, token string, functionID string, file string, insecure bool
 		return nil, fmt.Errorf("unable to read data file: %w", err)
 	}
 
-	token, err := getAuthToken()
-	if err != nil {
-		return nil, err
-	}
-
 	a := entities.FunctionAuth{
 		Token: token,
 		Type:  entities.AuthenticationTypeAuth0,
@@ -167,12 +162,12 @@ func Run(url string, token string, functionID string, file string, insecure bool
 
 	// TODO: Tuner may want to verify function hash later.
 	res, err := sdk.Run(sdk.RunRequest{
-		URL:        url,
-		FunctionID: functionID,
-		Data:       input,
-		Insecure:   insecure,
-		PcrSlice:   []string{},
-		FunctionAuth:  a,
+		URL:          url,
+		FunctionID:   functionID,
+		Data:         input,
+		Insecure:     insecure,
+		PcrSlice:     []string{},
+		FunctionAuth: a,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error processing data: %w", err)

--- a/cmd/cape/cmd/run.go
+++ b/cmd/cape/cmd/run.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
-	"github.com/capeprivacy/cli/entities"
 	"io"
 	"os"
+
+	"github.com/capeprivacy/cli/entities"
 
 	"github.com/spf13/cobra"
 

--- a/cmd/cape/cmd/run.go
+++ b/cmd/cape/cmd/run.go
@@ -123,7 +123,7 @@ func run(cmd *cobra.Command, args []string) error {
 	}
 
 	results, err := sdk.Run(sdk.RunRequest{
-		Url:           u,
+		URL:           u,
 		FunctionID:    functionID,
 		Data:          input,
 		Insecure:      insecure,
@@ -153,7 +153,7 @@ func Run(url string, functionID string, file string, insecure bool) ([]byte, err
 
 	// TODO: Tuner may want to verify function hash later.
 	res, err := sdk.Run(sdk.RunRequest{
-		Url:        url,
+		URL:        url,
 		FunctionID: functionID,
 		Data:       input,
 		Insecure:   insecure,

--- a/cmd/cape/cmd/test.go
+++ b/cmd/cape/cmd/test.go
@@ -80,7 +80,7 @@ func Test(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	res, err := test(sdk.TestRequest{Function: fnZip, Input: input, AuthToken: token}, u+"/v1/test", insecure)
+	res, err := test(sdk.TestRequest{Function: fnZip, Input: input, AuthToken: token, Insecure: insecure}, u+"/v1/test")
 	if err != nil {
 		return err
 	}

--- a/cmd/cape/cmd/test.go
+++ b/cmd/cape/cmd/test.go
@@ -94,4 +94,4 @@ func Test(cmd *cobra.Command, args []string) error {
 }
 
 var authToken = getAuthToken
-var test = sdk.CapeTest
+var test = sdk.Test

--- a/cmd/cape/cmd/test.go
+++ b/cmd/cape/cmd/test.go
@@ -10,7 +10,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/capeprivacy/cli/capetest"
+	"github.com/capeprivacy/cli/sdk"
 	czip "github.com/capeprivacy/cli/zip"
 )
 
@@ -80,7 +80,7 @@ func Test(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	res, err := test(capetest.TestRequest{Function: fnZip, Input: input, AuthToken: token}, u+"/v1/test", insecure)
+	res, err := test(sdk.TestRequest{Function: fnZip, Input: input, AuthToken: token}, u+"/v1/test", insecure)
 	if err != nil {
 		return err
 	}
@@ -94,4 +94,4 @@ func Test(cmd *cobra.Command, args []string) error {
 }
 
 var authToken = getAuthToken
-var test = capetest.CapeTest
+var test = sdk.CapeTest

--- a/cmd/cape/cmd/test_test.go
+++ b/cmd/cape/cmd/test_test.go
@@ -108,7 +108,7 @@ func TestServerError(t *testing.T) {
 	cmd.SetArgs([]string{"test", "testdata/my_fn", "hello world"})
 
 	errMsg := "something went wrong"
-	test = func(testReq sdk.TestRequest, endpoint string, insecure bool) (*entities.RunResults, error) {
+	test = func(testReq sdk.TestRequest, endpoint string) (*entities.RunResults, error) {
 		return nil, errors.New(errMsg)
 	}
 	authToken = func() (string, error) {
@@ -139,7 +139,7 @@ func TestSuccess(t *testing.T) {
 	results := "success!"
 	var gotFn []byte
 	var gotInput []byte
-	test = func(testReq sdk.TestRequest, endpoint string, insecure bool) (*entities.RunResults, error) {
+	test = func(testReq sdk.TestRequest, endpoint string) (*entities.RunResults, error) {
 		gotFn, gotInput = testReq.Function, testReq.Input
 		return &entities.RunResults{Message: []byte(results)}, nil
 	}
@@ -183,7 +183,7 @@ func TestSuccessStdin(t *testing.T) {
 	results := "success!"
 	var gotFn []byte
 	var gotInput []byte
-	test = func(testReq sdk.TestRequest, endpoint string, insecure bool) (*entities.RunResults, error) {
+	test = func(testReq sdk.TestRequest, endpoint string) (*entities.RunResults, error) {
 		gotFn, gotInput = testReq.Function, testReq.Input
 		return &entities.RunResults{Message: []byte(results)}, nil
 	}
@@ -227,7 +227,7 @@ func TestWSConnection(t *testing.T) {
 	type msg struct {
 		Message []byte `json:"msg"`
 	}
-	test = func(testReq sdk.TestRequest, endpoint string, insecure bool) (*entities.RunResults, error) {
+	test = func(testReq sdk.TestRequest, endpoint string) (*entities.RunResults, error) {
 		c, _, err := websocket.DefaultDialer.Dial(endpoint, nil)
 		if err != nil {
 			return nil, err
@@ -285,7 +285,7 @@ func TestWSConnection(t *testing.T) {
 func TestEndpoint(t *testing.T) {
 	// ensure that `cape test` hits the `/v1/test` endpoint
 	endpointHit := ""
-	test = func(testReq sdk.TestRequest, endpoint string, insecure bool) (*entities.RunResults, error) {
+	test = func(testReq sdk.TestRequest, endpoint string) (*entities.RunResults, error) {
 		endpointHit = endpoint
 		return &entities.RunResults{Message: []byte("good job")}, nil
 	}
@@ -313,7 +313,7 @@ func TestEndpoint(t *testing.T) {
 func TestEnvVarConfigEndpoint(t *testing.T) {
 	// ensure that env var overrides work for hostname
 	endpointHit := ""
-	test = func(testReq sdk.TestRequest, endpoint string, insecure bool) (*entities.RunResults, error) {
+	test = func(testReq sdk.TestRequest, endpoint string) (*entities.RunResults, error) {
 		endpointHit = endpoint
 		return &entities.RunResults{Message: []byte("good job")}, nil
 	}
@@ -346,7 +346,7 @@ func TestFileConfigEndpoint(t *testing.T) {
 	endpointHit := ""
 	fileEndpoint := "https://foo_file.capeprivacy.com"
 
-	test = func(testReq sdk.TestRequest, endpoint string, insecure bool) (*entities.RunResults, error) {
+	test = func(testReq sdk.TestRequest, endpoint string) (*entities.RunResults, error) {
 		endpointHit = endpoint
 		return &entities.RunResults{Message: []byte("good job")}, nil
 	}

--- a/cmd/cape/cmd/test_test.go
+++ b/cmd/cape/cmd/test_test.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/capeprivacy/cli/entities"
 
-	"github.com/capeprivacy/cli/capetest"
+	"github.com/capeprivacy/cli/sdk"
 	czip "github.com/capeprivacy/cli/zip"
 )
 
@@ -108,14 +108,14 @@ func TestServerError(t *testing.T) {
 	cmd.SetArgs([]string{"test", "testdata/my_fn", "hello world"})
 
 	errMsg := "something went wrong"
-	test = func(testReq capetest.TestRequest, endpoint string, insecure bool) (*entities.RunResults, error) {
+	test = func(testReq sdk.TestRequest, endpoint string, insecure bool) (*entities.RunResults, error) {
 		return nil, errors.New(errMsg)
 	}
 	authToken = func() (string, error) {
 		return "so logged in", nil
 	}
 	defer func() {
-		test = capetest.CapeTest
+		test = sdk.CapeTest
 		authToken = getAuthToken
 	}()
 
@@ -139,7 +139,7 @@ func TestSuccess(t *testing.T) {
 	results := "success!"
 	var gotFn []byte
 	var gotInput []byte
-	test = func(testReq capetest.TestRequest, endpoint string, insecure bool) (*entities.RunResults, error) {
+	test = func(testReq sdk.TestRequest, endpoint string, insecure bool) (*entities.RunResults, error) {
 		gotFn, gotInput = testReq.Function, testReq.Input
 		return &entities.RunResults{Message: []byte(results)}, nil
 	}
@@ -147,7 +147,7 @@ func TestSuccess(t *testing.T) {
 		return "so logged in", nil
 	}
 	defer func() {
-		test = capetest.CapeTest
+		test = sdk.CapeTest
 		authToken = getAuthToken
 	}()
 
@@ -183,7 +183,7 @@ func TestSuccessStdin(t *testing.T) {
 	results := "success!"
 	var gotFn []byte
 	var gotInput []byte
-	test = func(testReq capetest.TestRequest, endpoint string, insecure bool) (*entities.RunResults, error) {
+	test = func(testReq sdk.TestRequest, endpoint string, insecure bool) (*entities.RunResults, error) {
 		gotFn, gotInput = testReq.Function, testReq.Input
 		return &entities.RunResults{Message: []byte(results)}, nil
 	}
@@ -191,7 +191,7 @@ func TestSuccessStdin(t *testing.T) {
 		return "so logged in", nil
 	}
 	defer func() {
-		test = capetest.CapeTest
+		test = sdk.CapeTest
 		authToken = getAuthToken
 	}()
 
@@ -227,7 +227,7 @@ func TestWSConnection(t *testing.T) {
 	type msg struct {
 		Message []byte `json:"msg"`
 	}
-	test = func(testReq capetest.TestRequest, endpoint string, insecure bool) (*entities.RunResults, error) {
+	test = func(testReq sdk.TestRequest, endpoint string, insecure bool) (*entities.RunResults, error) {
 		c, _, err := websocket.DefaultDialer.Dial(endpoint, nil)
 		if err != nil {
 			return nil, err
@@ -245,7 +245,7 @@ func TestWSConnection(t *testing.T) {
 		return "so logged in", nil
 	}
 	defer func() {
-		test = capetest.CapeTest
+		test = sdk.CapeTest
 		authToken = getAuthToken
 	}()
 
@@ -285,7 +285,7 @@ func TestWSConnection(t *testing.T) {
 func TestEndpoint(t *testing.T) {
 	// ensure that `cape test` hits the `/v1/test` endpoint
 	endpointHit := ""
-	test = func(testReq capetest.TestRequest, endpoint string, insecure bool) (*entities.RunResults, error) {
+	test = func(testReq sdk.TestRequest, endpoint string, insecure bool) (*entities.RunResults, error) {
 		endpointHit = endpoint
 		return &entities.RunResults{Message: []byte("good job")}, nil
 	}
@@ -293,7 +293,7 @@ func TestEndpoint(t *testing.T) {
 		return "so logged in", nil
 	}
 	defer func() {
-		test = capetest.CapeTest
+		test = sdk.CapeTest
 		authToken = getAuthToken
 	}()
 
@@ -313,7 +313,7 @@ func TestEndpoint(t *testing.T) {
 func TestEnvVarConfigEndpoint(t *testing.T) {
 	// ensure that env var overrides work for hostname
 	endpointHit := ""
-	test = func(testReq capetest.TestRequest, endpoint string, insecure bool) (*entities.RunResults, error) {
+	test = func(testReq sdk.TestRequest, endpoint string, insecure bool) (*entities.RunResults, error) {
 		endpointHit = endpoint
 		return &entities.RunResults{Message: []byte("good job")}, nil
 	}
@@ -321,7 +321,7 @@ func TestEnvVarConfigEndpoint(t *testing.T) {
 		return "so logged in", nil
 	}
 	defer func() {
-		test = capetest.CapeTest
+		test = sdk.CapeTest
 		authToken = getAuthToken
 	}()
 
@@ -346,7 +346,7 @@ func TestFileConfigEndpoint(t *testing.T) {
 	endpointHit := ""
 	fileEndpoint := "https://foo_file.capeprivacy.com"
 
-	test = func(testReq capetest.TestRequest, endpoint string, insecure bool) (*entities.RunResults, error) {
+	test = func(testReq sdk.TestRequest, endpoint string, insecure bool) (*entities.RunResults, error) {
 		endpointHit = endpoint
 		return &entities.RunResults{Message: []byte("good job")}, nil
 	}
@@ -358,7 +358,7 @@ func TestFileConfigEndpoint(t *testing.T) {
 		return nil
 	}
 	defer func() {
-		test = capetest.CapeTest
+		test = sdk.CapeTest
 		authToken = getAuthToken
 		readConfFile = viper.ReadInConfig
 	}()

--- a/cmd/cape/cmd/test_test.go
+++ b/cmd/cape/cmd/test_test.go
@@ -115,7 +115,7 @@ func TestServerError(t *testing.T) {
 		return "so logged in", nil
 	}
 	defer func() {
-		test = sdk.CapeTest
+		test = sdk.Test
 		authToken = getAuthToken
 	}()
 
@@ -147,7 +147,7 @@ func TestSuccess(t *testing.T) {
 		return "so logged in", nil
 	}
 	defer func() {
-		test = sdk.CapeTest
+		test = sdk.Test
 		authToken = getAuthToken
 	}()
 
@@ -191,7 +191,7 @@ func TestSuccessStdin(t *testing.T) {
 		return "so logged in", nil
 	}
 	defer func() {
-		test = sdk.CapeTest
+		test = sdk.Test
 		authToken = getAuthToken
 	}()
 
@@ -245,7 +245,7 @@ func TestWSConnection(t *testing.T) {
 		return "so logged in", nil
 	}
 	defer func() {
-		test = sdk.CapeTest
+		test = sdk.Test
 		authToken = getAuthToken
 	}()
 
@@ -293,7 +293,7 @@ func TestEndpoint(t *testing.T) {
 		return "so logged in", nil
 	}
 	defer func() {
-		test = sdk.CapeTest
+		test = sdk.Test
 		authToken = getAuthToken
 	}()
 
@@ -321,7 +321,7 @@ func TestEnvVarConfigEndpoint(t *testing.T) {
 		return "so logged in", nil
 	}
 	defer func() {
-		test = sdk.CapeTest
+		test = sdk.Test
 		authToken = getAuthToken
 	}()
 
@@ -358,7 +358,7 @@ func TestFileConfigEndpoint(t *testing.T) {
 		return nil
 	}
 	defer func() {
-		test = sdk.CapeTest
+		test = sdk.Test
 		authToken = getAuthToken
 		readConfFile = viper.ReadInConfig
 	}()

--- a/sdk/deploy.go
+++ b/sdk/deploy.go
@@ -38,6 +38,7 @@ type DeployRequest struct {
 	Insecure               bool
 	PcrSlice               []string
 	FunctionTokenPublicKey string
+	AuthType               entities.AuthenticationType
 }
 
 func Deploy(req DeployRequest) (string, []byte, error) {
@@ -69,7 +70,9 @@ func Deploy(req DeployRequest) (string, []byte, error) {
 		return "", nil, err
 	}
 
-	r := entities.StartRequest{Nonce: []byte(nonce), AuthToken: req.Token}
+	metadata := entities.FunctionMetadata{FunctionAuthenticationType: string(req.AuthType)}
+
+	r := entities.StartRequest{Nonce: []byte(nonce), AuthToken: req.Token, Metadata: metadata}
 	log.Debug("\n> Sending Nonce and Auth Token")
 	if err := p.WriteStart(r); err != nil {
 		log.Error("error writing deploy request")

--- a/sdk/deploy.go
+++ b/sdk/deploy.go
@@ -1,0 +1,154 @@
+package sdk
+
+import "C"
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/gorilla/websocket"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/capeprivacy/cli/attest"
+	"github.com/capeprivacy/cli/crypto"
+	"github.com/capeprivacy/cli/entities"
+	proto "github.com/capeprivacy/cli/protocol"
+)
+
+type Protocol interface {
+	WriteStart(request entities.StartRequest) error
+	ReadAttestationDoc() ([]byte, error)
+	ReadRunResults() (*entities.RunResults, error)
+	WriteBinary([]byte) error
+	WriteFunctionPublicKey(key string) error
+	ReadDeploymentResults() (*entities.SetDeploymentIDRequest, error)
+}
+
+func GetProtocol(ws *websocket.Conn) Protocol {
+	return proto.Protocol{Websocket: ws}
+}
+
+type DeployRequest struct {
+	Url                    string
+	Token                  string
+	Name                   string
+	Reader                 io.Reader
+	Insecure               bool
+	PcrSlice               []string
+	FunctionTokenPublicKey string
+}
+
+func Deploy(req DeployRequest) (string, []byte, error) {
+	endpoint := fmt.Sprintf("%s/v1/deploy", req.Url)
+
+	log.Info("Deploying function to Cape ...")
+
+	conn, res, err := WebsocketDial(endpoint, req.Insecure, req.Token)
+	if err != nil {
+		log.Error("error dialing websocket: ", err)
+		// This check is necessary because we don't necessarily return an http response from sentinel.
+		// Http error code and message is returned if network routing fails.
+		if res != nil {
+			var e ErrorMsg
+			if err := json.NewDecoder(res.Body).Decode(&e); err != nil {
+				return "", nil, err
+			}
+			res.Body.Close()
+			return "", nil, fmt.Errorf("error code: %d, reason: %s", res.StatusCode, e.Error)
+		}
+		return "", nil, err
+	}
+	defer conn.Close()
+
+	p := GetProtocol(conn)
+
+	nonce, err := crypto.GetNonce()
+	if err != nil {
+		return "", nil, err
+	}
+
+	r := entities.StartRequest{Nonce: []byte(nonce), AuthToken: req.Token}
+	log.Debug("\n> Sending Nonce and Auth Token")
+	if err := p.WriteStart(r); err != nil {
+		log.Error("error writing deploy request")
+		return "", nil, err
+	}
+
+	log.Debug("* Waiting for attestation document...")
+
+	attestDoc, err := p.ReadAttestationDoc()
+	if err != nil {
+		log.Error("error reading attestation doc")
+		return "", nil, err
+	}
+
+	log.Debug("< Downloading AWS Root Certificate")
+	rootCert, err := attest.GetRootAWSCert()
+	if err != nil {
+		return "", nil, err
+	}
+
+	log.Debug("< Attestation document")
+	doc, _, err := attest.Attest(attestDoc, rootCert)
+	if err != nil {
+		log.Error("error attesting")
+		return "", nil, err
+	}
+
+	hasher := sha256.New()
+	// tReader is used to stream data to the hasher function.
+	tReader := io.TeeReader(req.Reader, hasher)
+	plaintext, err := io.ReadAll(tReader)
+	if err != nil {
+		log.Error("error reading plaintext function")
+		return "", nil, err
+	}
+
+	// Print out the hash to the user.
+	hash := hasher.Sum(nil)
+	ciphertext, err := crypto.LocalEncrypt(*doc, plaintext)
+	if err != nil {
+		log.Error("error encrypting function")
+		return "", nil, err
+	}
+
+	log.Debug("\n> Sending Public Key")
+	if err := p.WriteFunctionPublicKey(req.FunctionTokenPublicKey); err != nil {
+		log.Error("error sending public key")
+		return "", nil, err
+	}
+
+	log.Debug("\n> Deploying Encrypted Function")
+	err = writeFunction(conn, bytes.NewBuffer(ciphertext))
+	if err != nil {
+		return "", nil, err
+	}
+
+	log.Debug("* Waiting for deploy response...")
+
+	resData, err := p.ReadDeploymentResults()
+	if err != nil {
+		return "", nil, err
+	}
+	log.Debugf("< Received Deploy Response %v", resData)
+
+	return resData.ID, hash, nil
+}
+
+func writeFunction(conn *websocket.Conn, reader io.Reader) error {
+	writer, err := conn.NextWriter(websocket.BinaryMessage)
+	if err != nil {
+		log.Errorf("error getting writer for function: %v", err)
+		return err
+	}
+	defer writer.Close()
+
+	_, err = io.Copy(writer, reader)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/sdk/deploy.go
+++ b/sdk/deploy.go
@@ -30,7 +30,7 @@ func GetProtocol(ws *websocket.Conn) Protocol {
 }
 
 type DeployRequest struct {
-	Url                    string
+	URL                    string
 	Name                   string
 	Reader                 io.Reader
 	PcrSlice               []string
@@ -44,7 +44,7 @@ type DeployRequest struct {
 // Deploy encrypts the given function data within a secure enclave and stores the encrypted function for future use.
 // Returns a function ID upon successful deployment. The stored function can only be decrypted within an enclave.
 func Deploy(req DeployRequest) (string, []byte, error) {
-	endpoint := fmt.Sprintf("%s/v1/deploy", req.Url)
+	endpoint := fmt.Sprintf("%s/v1/deploy", req.URL)
 
 	log.Info("Deploying function to Cape ...")
 

--- a/sdk/deploy.go
+++ b/sdk/deploy.go
@@ -35,7 +35,7 @@ type DeployRequest struct {
 	Reader                 io.Reader
 	PcrSlice               []string
 	FunctionTokenPublicKey string
-	FunctionAuth           entities.FunctionAuth
+	AuthToken              string
 
 	// For development use only: circumvents some token authorization when true
 	Insecure bool
@@ -48,8 +48,7 @@ func Deploy(req DeployRequest) (string, []byte, error) {
 
 	log.Info("Deploying function to Cape ...")
 
-	auth := req.FunctionAuth
-	conn, res, err := WebsocketDial(endpoint, req.Insecure, string(auth.Type), auth.Token)
+	conn, res, err := WebsocketDial(endpoint, req.Insecure, "cape.runtime", req.AuthToken)
 	if err != nil {
 		log.Error("error dialing websocket: ", err)
 		// This check is necessary because we don't necessarily return an http response from sentinel.
@@ -73,7 +72,7 @@ func Deploy(req DeployRequest) (string, []byte, error) {
 		return "", nil, err
 	}
 
-	r := entities.StartRequest{Nonce: []byte(nonce), AuthToken: auth.Token}
+	r := entities.StartRequest{Nonce: []byte(nonce), AuthToken: req.AuthToken}
 	log.Debug("\n> Sending Nonce and Auth Token")
 	if err := p.WriteStart(r); err != nil {
 		log.Error("error writing deploy request")

--- a/sdk/deploy.go
+++ b/sdk/deploy.go
@@ -1,6 +1,5 @@
 package sdk
 
-import "C"
 import (
 	"bytes"
 	"crypto/sha256"

--- a/sdk/run.go
+++ b/sdk/run.go
@@ -1,0 +1,136 @@
+package sdk
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+
+	"github.com/gorilla/websocket"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/capeprivacy/cli/attest"
+	"github.com/capeprivacy/cli/crypto"
+	"github.com/capeprivacy/cli/entities"
+)
+
+type RunRequest struct {
+	Url           string
+	FunctionID    string
+	Data          []byte
+	Insecure      bool
+	FuncHash      []byte
+	KeyPolicyHash []byte
+	PcrSlice      []string
+	AuthToken     string
+}
+
+func Run(req RunRequest) ([]byte, error) {
+	endpoint := fmt.Sprintf("%s/v1/run/%s", req.Url, req.FunctionID)
+
+	c, res, err := WebsocketDial(endpoint, req.Insecure, req.AuthToken)
+	if err != nil {
+		log.Error("error dialing websocket: ", err)
+		// This check is necessary because we don't necessarily return an http response from sentinel.
+		// Http error code and message is returned if network routing fails.
+		if res != nil {
+			var e ErrorMsg
+			if err := json.NewDecoder(res.Body).Decode(&e); err != nil {
+				return nil, err
+			}
+			res.Body.Close()
+			return nil, fmt.Errorf("error code: %d, reason: %s", res.StatusCode, e.Error)
+		}
+		return nil, err
+	}
+	defer c.Close()
+
+	nonce, err := crypto.GetNonce()
+	if err != nil {
+		return nil, err
+	}
+
+	p := GetProtocol(c)
+
+	r := entities.StartRequest{Nonce: []byte(nonce), AuthToken: req.AuthToken}
+	log.Debug("\n> Sending Nonce and Auth Token")
+	err = p.WriteStart(r)
+	if err != nil {
+		return nil, errors.Wrap(err, "error writing run request")
+	}
+
+	log.Debug("* Waiting for attestation document...")
+
+	attestDoc, err := p.ReadAttestationDoc()
+	if err != nil {
+		log.Println("error reading attestation doc")
+		return nil, err
+	}
+
+	log.Debug("< Downloading AWS Root Certificate")
+	rootCert, err := attest.GetRootAWSCert()
+	if err != nil {
+		return nil, err
+	}
+
+	log.Debug("< Auth Completed. Received Attestation Document")
+	doc, userData, err := attest.Attest(attestDoc, rootCert)
+	if err != nil {
+		log.Println("error attesting")
+		return nil, err
+	}
+
+	if userData.FuncHash == nil && len(req.FuncHash) > 0 {
+		return nil, fmt.Errorf("did not receive function hash from enclave")
+	}
+
+	// If function hash as an optional parameter has not been specified by the user, then we don't check the value.
+	if len(req.FuncHash) > 0 && !reflect.DeepEqual(req.FuncHash, userData.FuncHash) {
+		return nil, fmt.Errorf("returned function hash did not match provided, got: %x, want %x", userData.FuncHash, req.FuncHash)
+	}
+
+	if userData.KeyPolicyHash == nil && len(req.KeyPolicyHash) > 0 {
+		return nil, fmt.Errorf("did not receive key policy hash from enclave")
+	}
+
+	if len(req.KeyPolicyHash) > 0 && !reflect.DeepEqual(req.KeyPolicyHash, userData.KeyPolicyHash) {
+		return nil, fmt.Errorf("returned key policy hash did not match provided, got: %x, want %x", userData.KeyPolicyHash, req.KeyPolicyHash)
+	}
+
+	encryptedData, err := crypto.LocalEncrypt(*doc, req.Data)
+	if err != nil {
+		log.Println("error encrypting")
+		return nil, err
+	}
+
+	log.Debug("\n> Sending Encrypted Inputs")
+	err = writeData(c, encryptedData)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Debug("* Waiting for function results...")
+
+	resData, err := p.ReadRunResults()
+	if err != nil {
+		return nil, err
+	}
+	log.Debugf("< Received Function Results.")
+
+	return resData.Message, nil
+}
+
+func writeData(conn *websocket.Conn, data []byte) error {
+	w, err := conn.NextWriter(websocket.BinaryMessage)
+	if err != nil {
+		return err
+	}
+	defer w.Close()
+
+	_, err = w.Write(data)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/sdk/run.go
+++ b/sdk/run.go
@@ -15,7 +15,7 @@ import (
 )
 
 type RunRequest struct {
-	Url           string
+	URL           string
 	FunctionID    string
 	Data          []byte
 	Insecure      bool
@@ -26,7 +26,7 @@ type RunRequest struct {
 }
 
 func Run(req RunRequest) ([]byte, error) {
-	endpoint := fmt.Sprintf("%s/v1/run/%s", req.Url, req.FunctionID)
+	endpoint := fmt.Sprintf("%s/v1/run/%s", req.URL, req.FunctionID)
 
 	c, res, err := WebsocketDial(endpoint, req.Insecure, req.AuthToken)
 	if err != nil {

--- a/sdk/run.go
+++ b/sdk/run.go
@@ -23,7 +23,7 @@ type RunRequest struct {
 	PcrSlice      []string
 	FunctionAuth  entities.FunctionAuth
 
-	// For development use only: circumvents some authorization steps when true
+	// For development use only: skips validating TLS certificate from the URL
 	Insecure bool
 }
 
@@ -36,7 +36,7 @@ func Run(req RunRequest) ([]byte, error) {
 	if auth.Type == entities.AuthenticationTypeFunctionToken {
 		authProtocolType = "cape.function"
 	}
-	c, res, err := WebsocketDial(endpoint, req.Insecure, authProtocolType, auth.Token)
+	c, res, err := websocketDial(endpoint, req.Insecure, authProtocolType, auth.Token)
 	if err != nil {
 		log.Error("error dialing websocket: ", err)
 		// This check is necessary because we don't necessarily return an http response from sentinel.

--- a/sdk/run.go
+++ b/sdk/run.go
@@ -23,6 +23,7 @@ type RunRequest struct {
 	KeyPolicyHash []byte
 	PcrSlice      []string
 	AuthToken     string
+	FunctionToken string
 }
 
 func Run(req RunRequest) ([]byte, error) {

--- a/sdk/run.go
+++ b/sdk/run.go
@@ -58,7 +58,7 @@ func Run(req RunRequest) ([]byte, error) {
 		return nil, err
 	}
 
-	p := GetProtocol(c)
+	p := getProtocol(c)
 
 	r := entities.StartRequest{Nonce: []byte(nonce), AuthToken: auth.Token}
 	log.Debug("\n> Sending Nonce and Auth Token")

--- a/sdk/test.go
+++ b/sdk/test.go
@@ -1,4 +1,4 @@
-package capetest
+package sdk
 
 import (
 	"crypto/tls"
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 
-	proto "github.com/capeprivacy/cli/protocol"
 	"github.com/gorilla/websocket"
 	log "github.com/sirupsen/logrus"
 
@@ -22,13 +21,11 @@ type TestRequest struct {
 	AuthToken string
 }
 
-// TODO -- cmd package also defines this
 type ErrorMsg struct {
 	Error string `json:"error"`
 }
 
-// TODO -- cmd package also defines this
-func websocketDial(url string, insecure bool, authToken string) (*websocket.Conn, *http.Response, error) {
+func WebsocketDial(url string, insecure bool, authToken string) (*websocket.Conn, *http.Response, error) {
 	if insecure {
 		websocket.DefaultDialer.TLSClientConfig = &tls.Config{
 			InsecureSkipVerify: true,
@@ -52,21 +49,10 @@ func websocketDial(url string, insecure bool, authToken string) (*websocket.Conn
 	return c, r, nil
 }
 
-type Protocol interface {
-	WriteStart(request entities.StartRequest) error
-	ReadAttestationDoc() ([]byte, error)
-	ReadRunResults() (*entities.RunResults, error)
-	WriteBinary([]byte) error
-}
-
-func protocol(ws *websocket.Conn) Protocol {
-	return proto.Protocol{Websocket: ws}
-}
-
-var getProtocol = protocol
+var getProtocol = GetProtocol
 
 func CapeTest(testReq TestRequest, endpoint string, insecure bool) (*entities.RunResults, error) {
-	conn, resp, err := websocketDial(endpoint, insecure, testReq.AuthToken)
+	conn, resp, err := WebsocketDial(endpoint, insecure, testReq.AuthToken)
 	if err != nil {
 		log.Error("error dialing websocket", err)
 		// This check is necessary because we don't necessarily return an http response from sentinel.

--- a/sdk/test.go
+++ b/sdk/test.go
@@ -9,8 +9,6 @@ import (
 	"github.com/gorilla/websocket"
 	log "github.com/sirupsen/logrus"
 
-	proto "github.com/capeprivacy/cli/protocol"
-
 	"github.com/capeprivacy/cli/entities"
 
 	"github.com/capeprivacy/cli/attest"

--- a/sdk/test.go
+++ b/sdk/test.go
@@ -54,7 +54,7 @@ func Test(testReq TestRequest, endpoint string) (*entities.RunResults, error) {
 		return nil, err
 	}
 
-	p := getProtocol(conn)
+	p := getProtocolFn(conn)
 
 	startReq := entities.StartRequest{
 		AuthToken: testReq.AuthToken,
@@ -135,5 +135,6 @@ func websocketDial(url string, insecure bool, authProtocolType string, authToken
 	return c, r, nil
 }
 
+var getProtocolFn = getProtocol
 var runAttestation = attest.Attest
 var localEncrypt = crypto.LocalEncrypt

--- a/sdk/test.go
+++ b/sdk/test.go
@@ -28,11 +28,11 @@ type ErrorMsg struct {
 	Error string `json:"error"`
 }
 
-// CapeTest simulates the workflow of Deploy and Run, without storing the function.
+// Test simulates the workflow of Deploy and Run, without storing the function.
 // It loads the given function into an enclave, runs it on the given data, and returns the result.
-// Use CapeTest to verify that your function will work before storing it via Deploy.
-func CapeTest(testReq TestRequest, endpoint string) (*entities.RunResults, error) {
-	conn, resp, err := WebsocketDial(endpoint, testReq.Insecure, "cape.runtime", testReq.AuthToken)
+// Use Test to verify that your function will work before storing it via Deploy.
+func Test(testReq TestRequest, endpoint string) (*entities.RunResults, error) {
+	conn, resp, err := websocketDial(endpoint, testReq.Insecure, "cape.runtime", testReq.AuthToken)
 	if err != nil {
 		log.Error("error dialing websocket", err)
 		// This check is necessary because we don't necessarily return an http response from sentinel.
@@ -111,7 +111,7 @@ func CapeTest(testReq TestRequest, endpoint string) (*entities.RunResults, error
 	return res, nil
 }
 
-func WebsocketDial(url string, insecure bool, authProtocolType string, authToken string) (*websocket.Conn, *http.Response, error) {
+func websocketDial(url string, insecure bool, authProtocolType string, authToken string) (*websocket.Conn, *http.Response, error) {
 	if insecure {
 		websocket.DefaultDialer.TLSClientConfig = &tls.Config{
 			InsecureSkipVerify: true,
@@ -135,6 +135,5 @@ func WebsocketDial(url string, insecure bool, authProtocolType string, authToken
 	return c, r, nil
 }
 
-var getProtocol = GetProtocol
 var runAttestation = attest.Attest
 var localEncrypt = crypto.LocalEncrypt

--- a/sdk/test_test.go
+++ b/sdk/test_test.go
@@ -51,7 +51,7 @@ func TestCapeTest(t *testing.T) {
 	}
 	localEncrypt = func(doc attest.AttestationDoc, plaintext []byte) ([]byte, error) { return plaintext, nil }
 
-	getProtocol = func(ws *websocket.Conn) Protocol {
+	getProtocolFn = func(ws *websocket.Conn) protocol {
 		return testProtocol{
 			start:  func(req entities.StartRequest) error { return nil },
 			attest: func() ([]byte, error) { return []byte{}, nil },

--- a/sdk/test_test.go
+++ b/sdk/test_test.go
@@ -78,9 +78,10 @@ func TestCapeTest(t *testing.T) {
 	test := TestRequest{
 		Function: []byte("myfn"),
 		Input:    []byte("myinput"),
+		Insecure: true,
 	}
 
-	res, err := CapeTest(test, wsURL(s.URL), true)
+	res, err := CapeTest(test, wsURL(s.URL))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sdk/test_test.go
+++ b/sdk/test_test.go
@@ -1,4 +1,4 @@
-package capetest
+package sdk
 
 import (
 	"crypto/x509"
@@ -19,6 +19,14 @@ type testProtocol struct {
 	attest  func() ([]byte, error)
 	results func() (*entities.RunResults, error)
 	binary  func(b []byte) error
+}
+
+func (t testProtocol) WriteFunctionPublicKey(key string) error {
+	return nil
+}
+
+func (t testProtocol) ReadDeploymentResults() (*entities.SetDeploymentIDRequest, error) {
+	return nil, nil
 }
 
 func (t testProtocol) WriteStart(request entities.StartRequest) error {

--- a/sdk/test_test.go
+++ b/sdk/test_test.go
@@ -81,7 +81,7 @@ func TestCapeTest(t *testing.T) {
 		Insecure: true,
 	}
 
-	res, err := CapeTest(test, wsURL(s.URL))
+	res, err := Test(test, wsURL(s.URL))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
- converted CapeTest into the sdk package
- sdk pulls in attest, crypto, entities, and protocol as dependencies from within the repo
- Deploy, Run, and CapeTest sdk functions
- refactored Deploy and Run to take a request object the way CapeTest does

I tried to be thorough in my refactors and merge conflict resolutions, but please review with careful eyes in case something slipped by me! :smiley: 