### PR TITLE
Renaming function hash to checksum for clarity of use

### DIFF
--- a/cmd/cape/cmd/deploy.go
+++ b/cmd/cape/cmd/deploy.go
@@ -92,7 +92,7 @@ func deploy(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	log.Infof("Success! Deployed function to Cape\nFunction ID ➜ %s\nFunction Hash ➜ %x\n", dID, hash)
+	log.Infof("Success! Deployed function to Cape\nFunction ID ➜ %s\nChecksum ➜ %x\n", dID, hash)
 
 	return nil
 }

--- a/cmd/cape/cmd/run.go
+++ b/cmd/cape/cmd/run.go
@@ -59,7 +59,7 @@ func init() {
 	runCmd.PersistentFlags().StringP("key-policy-hash", "", "", "key policy hash to attest")
 	runCmd.PersistentFlags().StringSliceP("pcr", "p", []string{""}, "pass multiple PCRs to validate against")
 
-	err := runCmd.Flags().MarkDeprecated("function-hash", "this flag has been deprecated for renaming, use 'checksum' instead")
+	err := runCmd.PersistentFlags().MarkDeprecated("function-hash", "this flag has been deprecated for renaming, use 'checksum' instead")
 	if err != nil {
 		log.WithError(err).Error("unable to set flag 'function-hash' as deprecated")
 	}

--- a/sdk/run.go
+++ b/sdk/run.go
@@ -89,12 +89,12 @@ func Run(req RunRequest) ([]byte, error) {
 	}
 
 	if userData.FuncHash == nil && len(req.FuncHash) > 0 {
-		return nil, fmt.Errorf("did not receive function hash from enclave")
+		return nil, fmt.Errorf("did not receive checksum from enclave")
 	}
 
-	// If function hash as an optional parameter has not been specified by the user, then we don't check the value.
+	// If checksum as an optional parameter has not been specified by the user, then we don't check the value.
 	if len(req.FuncHash) > 0 && !reflect.DeepEqual(req.FuncHash, userData.FuncHash) {
-		return nil, fmt.Errorf("returned function hash did not match provided, got: %x, want %x", userData.FuncHash, req.FuncHash)
+		return nil, fmt.Errorf("returned checksum did not match provided, got: %x, want %x", userData.FuncHash, req.FuncHash)
 	}
 
 	if userData.KeyPolicyHash == nil && len(req.KeyPolicyHash) > 0 {


### PR DESCRIPTION
`function-hash` option has been marked deprecated with messaging, use `checksum` instead