### PR TITLE
Fixup imports and update linter config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,4 +17,4 @@ linters:
     - staticcheck
 linters-settings:
   goimports:
-    local-prefixes: github.com/capeprivacy/maestro
+    local-prefixes: github.com/capeprivacy

--- a/cmd/cape/cmd/run.go
+++ b/cmd/cape/cmd/run.go
@@ -8,11 +8,9 @@ import (
 	"os"
 
 	log "github.com/sirupsen/logrus"
-
-	"github.com/capeprivacy/cli/entities"
-
 	"github.com/spf13/cobra"
 
+	"github.com/capeprivacy/cli/entities"
 	"github.com/capeprivacy/cli/sdk"
 )
 

--- a/cmd/cape/cmd/test_test.go
+++ b/cmd/cape/cmd/test_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/capeprivacy/cli/entities"
-
 	"github.com/capeprivacy/cli/sdk"
 	czip "github.com/capeprivacy/cli/zip"
 )

--- a/sdk/test.go
+++ b/sdk/test.go
@@ -10,10 +10,9 @@ import (
 	"github.com/gorilla/websocket"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/capeprivacy/cli/entities"
-
 	"github.com/capeprivacy/cli/attest"
 	"github.com/capeprivacy/cli/crypto"
+	"github.com/capeprivacy/cli/entities"
 )
 
 type TestRequest struct {

--- a/sdk/test_test.go
+++ b/sdk/test_test.go
@@ -9,9 +9,8 @@ import (
 
 	"github.com/gorilla/websocket"
 
-	"github.com/capeprivacy/cli/entities"
-
 	"github.com/capeprivacy/cli/attest"
+	"github.com/capeprivacy/cli/entities"
 )
 
 type testProtocol struct {


### PR DESCRIPTION
Fixes up the grouping for local dependencies, and switches linter config
to use the correct prefix for those dependencies.
