### PR TITLE
Add optional output formats

### DIFF
--- a/cmd/cape/cmd/deploy.go
+++ b/cmd/cape/cmd/deploy.go
@@ -92,7 +92,10 @@ func deploy(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	log.Infof("Success! Deployed function to Cape\nFunction ID ➜ %s\nChecksum ➜ %x\n", dID, checksum)
+	log.WithFields(log.Fields{
+		"function_id":       dID,
+		"function_checksum": fmt.Sprintf("%x", checksum),
+	}).Info("Success! Deployed function to Cape")
 
 	return nil
 }

--- a/cmd/cape/cmd/plain_formatter.go
+++ b/cmd/cape/cmd/plain_formatter.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+type PlainFormatter struct{}
+
+func (f *PlainFormatter) Format(entry *log.Entry) ([]byte, error) {
+	var buf bytes.Buffer
+	fmt.Fprintln(&buf, entry.Message)
+	for k, v := range entry.Data {
+		fmt.Fprintf(&buf, "%s ➜ %s\n", munge(k), v)
+	}
+	return buf.Bytes(), nil
+}
+
+func munge(s string) string {
+	s = strings.ReplaceAll(s, "_", " ")
+	return cases.Title(language.English).String(s)
+}

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/lithammer/shortuuid/v4 v4.0.0
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.4.0
+	golang.org/x/text v0.3.7
 )
 
 require (
@@ -38,7 +39,6 @@ require (
 	github.com/subosito/gotenv v1.2.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	golang.org/x/sys v0.0.0-20220412211240-33da011f77ad // indirect
-	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/protobuf v1.28.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 	gopkg.in/ini.v1 v1.66.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -180,6 +180,7 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
@@ -357,6 +358,7 @@ golang.org/x/net v0.0.0-20201224014010-6772e930b67b/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
+golang.org/x/net v0.0.0-20220412020605-290c469a71a5 h1:bRb386wvrE+oBNdF1d/Xh9mQrfQ4ecYhW5qJ5GvTGT4=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=


### PR DESCRIPTION
Adds a flag for selecting an output format. Augments the "plain"
formatter to allow adding fields to a log line which will be converted
to a human-readable key-value pair for output.

For example, a log message "Success! Deployed function to Cape" with
fields "function_id" and "function_checksum" will output:

```
Success! Deployed function to Cape
Function Id ➜ 8fjVmYEXAMPLECdNmq6MCa
Function Checksum ➜ cbca8c9f7ac411381EXAMPLE5a37b1fc09a11dfbc3d44b47
```

Specifying "plain" or omitting the flag will retain the previous
behavior. Specifying "json" will json format the output, and "log" or
"log_plain" will log-format the output with or without optional color
for TTYs, respectively.
