### PR TITLE
improved sdk with cape object

### DIFF
--- a/cmd/cape/cmd/run.go
+++ b/cmd/cape/cmd/run.go
@@ -177,13 +177,15 @@ func run(cmd *cobra.Command, args []string) error {
 
 	results, err := sdk.Run(sdk.RunRequest{
 		URL:          u,
-		FunctionID:   functionID,
 		Data:         input,
-		Insecure:     insecure,
-		FuncChecksum: funcChecksum,
-		KeyChecksum:  keyChecksum,
-		PcrSlice:     pcrSlice,
 		FunctionAuth: auth,
+		ConnectRequest: sdk.ConnectRequest{
+			FunctionID:   functionID,
+			Insecure:     insecure,
+			FuncChecksum: funcChecksum,
+			KeyChecksum:  keyChecksum,
+			PcrSlice:     pcrSlice,
+		},
 	})
 	if err != nil {
 		return fmt.Errorf("error processing data: %w", err)
@@ -203,11 +205,13 @@ func Run(url string, auth entities.FunctionAuth, functionID string, file string,
 	// TODO: Tuner may want to verify function checksum later.
 	res, err := sdk.Run(sdk.RunRequest{
 		URL:          url,
-		FunctionID:   functionID,
-		Data:         input,
-		Insecure:     insecure,
-		PcrSlice:     []string{},
 		FunctionAuth: auth,
+		Data:         input,
+		ConnectRequest: sdk.ConnectRequest{
+			FunctionID: functionID,
+			Insecure:   insecure,
+			PcrSlice:   []string{},
+		},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error processing data: %w", err)

--- a/sdk/cape.go
+++ b/sdk/cape.go
@@ -1,0 +1,49 @@
+package sdk
+
+import (
+	"github.com/capeprivacy/cli/attest"
+	"github.com/capeprivacy/cli/entities"
+	"github.com/gorilla/websocket"
+)
+
+// The Cape struct is used to manage a connection to a secure enclave, especially when used for multiple function invocations
+type Cape struct {
+	// Configuration variables to set up the connection
+	URL          string
+	FunctionAuth entities.FunctionAuth
+
+	// Internal state used to persist the connection
+	conn *websocket.Conn
+	doc  *attest.AttestationDoc
+}
+
+func (c Cape) Run(connReq ConnectRequest, data []byte) ([]byte, error) {
+
+	err := c.Connect(connReq)
+	if err != nil {
+		return nil, err
+	}
+	defer c.Disconnect()
+	return invoke(c, data)
+}
+
+func (c Cape) Connect(req ConnectRequest) error {
+	return connect(c, req)
+}
+
+func (c Cape) Disconnect() error {
+	if c.conn != nil {
+		err := c.conn.Close()
+		if err != nil {
+			return err
+		}
+	}
+	c.conn = nil
+	c.doc = nil
+
+	return nil
+}
+
+func (c Cape) Invoke(data []byte) ([]byte, error) {
+	return invoke(c, data)
+}

--- a/sdk/run.go
+++ b/sdk/run.go
@@ -15,13 +15,18 @@ import (
 )
 
 type RunRequest struct {
+	ConnectRequest
+
 	URL          string
-	FunctionID   string
 	Data         []byte
+	FunctionAuth entities.FunctionAuth
+}
+
+type ConnectRequest struct {
+	FunctionID   string
 	FuncChecksum []byte
 	KeyChecksum  []byte
 	PcrSlice     []string
-	FunctionAuth entities.FunctionAuth
 
 	// For development use only: skips validating TLS certificate from the URL
 	Insecure bool
@@ -29,23 +34,35 @@ type RunRequest struct {
 
 // Run loads the given function into a secure enclave and invokes it on the given data, then returns the result.
 func Run(req RunRequest) ([]byte, error) {
-	endpoint := fmt.Sprintf("%s/v1/run/%s", req.URL, req.FunctionID)
+	cape := Cape{
+		URL:          req.URL,
+		FunctionAuth: req.FunctionAuth,
+	}
+	err := connect(cape, req.ConnectRequest)
+	if err != nil {
+		return nil, err
+	}
+	defer cape.Disconnect()
+	return invoke(cape, req.Data)
+}
+
+func connect(cape Cape, req ConnectRequest) error {
+	endpoint := fmt.Sprintf("%s/v1/run/%s", cape.URL, req.FunctionID)
 
 	authProtocolType := "cape.runtime"
-	auth := req.FunctionAuth
+	auth := cape.FunctionAuth
 	if auth.Type == entities.AuthenticationTypeFunctionToken {
 		authProtocolType = "cape.function"
 	}
 
 	conn, err := doDial(endpoint, req.Insecure, authProtocolType, auth.Token)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	defer conn.Close()
 
 	nonce, err := crypto.GetNonce()
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	p := getProtocol(conn)
@@ -54,7 +71,7 @@ func Run(req RunRequest) ([]byte, error) {
 	log.Debug("\n> Sending Nonce and Auth Token")
 	err = p.WriteStart(r)
 	if err != nil {
-		return nil, errors.Wrap(err, "error writing run request")
+		return errors.Wrap(err, "error writing run request")
 	}
 
 	log.Debug("* Waiting for attestation document...")
@@ -62,60 +79,76 @@ func Run(req RunRequest) ([]byte, error) {
 	attestDoc, err := p.ReadAttestationDoc()
 	if err != nil {
 		log.Println("error reading attestation doc")
-		return nil, err
+		return err
 	}
 
 	log.Debug("< Downloading AWS Root Certificate")
 	rootCert, err := attest.GetRootAWSCert()
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	log.Debug("< Auth Completed. Received Attestation Document")
 	doc, userData, err := attest.Attest(attestDoc, rootCert)
 	if err != nil {
 		log.Println("error attesting")
-		return nil, err
+		return err
 	}
 
 	err = pcrs.VerifyPCRs(pcrs.SliceToMapStringSlice(req.PcrSlice), doc)
 	if err != nil {
 		log.Println("error verifying PCRs")
-		return nil, err
+		return err
 	}
 
 	if userData.FuncChecksum == nil && len(req.FuncChecksum) > 0 {
-		return nil, fmt.Errorf("did not receive checksum from enclave")
+		return fmt.Errorf("did not receive checksum from enclave")
 	}
 
 	// If checksum as an optional parameter has not been specified by the user, then we don't check the value.
 	if len(req.FuncChecksum) > 0 && !reflect.DeepEqual(req.FuncChecksum, userData.FuncChecksum) {
-		return nil, fmt.Errorf("returned checksum did not match provided, got: %x, want %x", userData.FuncChecksum, req.FuncChecksum)
+		return fmt.Errorf("returned checksum did not match provided, got: %x, want %x", userData.FuncChecksum, req.FuncChecksum)
 	}
 
 	if userData.KeyChecksum == nil && len(req.KeyChecksum) > 0 {
-		return nil, fmt.Errorf("did not receive key policy checksum from enclave")
+		return fmt.Errorf("did not receive key policy checksum from enclave")
 	}
 
 	if len(req.KeyChecksum) > 0 && !reflect.DeepEqual(req.KeyChecksum, userData.KeyChecksum) {
-		return nil, fmt.Errorf("returned key policy checksum did not match provided, got: %x, want %x", userData.KeyChecksum, req.KeyChecksum)
+		return fmt.Errorf("returned key policy checksum did not match provided, got: %x, want %x", userData.KeyChecksum, req.KeyChecksum)
 	}
 
-	encryptedData, err := crypto.LocalEncrypt(*doc, req.Data)
+	cape.conn = conn
+	cape.doc = doc
+
+	return nil
+}
+
+func invoke(cape Cape, data []byte) ([]byte, error) {
+	if cape.doc == nil {
+		log.Error("missing attestation document, you may need to run cape.Connect()")
+		return nil, errors.New("missing attestation document")
+	}
+	if cape.conn == nil {
+		log.Error("missing wesocket connection, you may need to run cape.Connect()")
+		return nil, errors.New("no active connection")
+	}
+
+	encryptedData, err := crypto.LocalEncrypt(*cape.doc, data)
 	if err != nil {
 		log.Println("error encrypting")
 		return nil, err
 	}
 
 	log.Debug("\n> Sending Encrypted Inputs")
-	err = writeData(conn, encryptedData)
+	err = writeData(cape.conn, encryptedData)
 	if err != nil {
 		return nil, err
 	}
 
 	log.Debug("* Waiting for function results...")
 
-	resData, err := p.ReadRunResults()
+	resData, err := getProtocol(cape.conn).ReadRunResults()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Split `Run` into `Connect` and `Invoke`, added `Disconnect`

Had a bit of an internal struggle around functional vs object-oriented, and it's currently halfway between two approaches. The CLI calls the methods in a functional way, passing everything as params, whereas the cape object stores state. the cape object is only needed for the connect/invoke workflow, the rest could just be called as functions, even by a developer using the go SDK.

I have `Run` creating a `Cape` object and throwing it away at the end, which seems wasteful. I think I should just pass a list of parameters as it used to be (but for Connect and Invoke)? And have `Cape` call those also passing its own params instead of itself. Also the nested request object is kinda ugly.

Sorry this isn't more coherent, I forgot to post an update and am now very sleepy :sweat_smile: