### PR TITLE
Introduce Renderer interface for formatting command output

### DIFF
--- a/cmd/cape/cmd/root.go
+++ b/cmd/cape/cmd/root.go
@@ -5,11 +5,12 @@ import (
 	"os"
 	"strings"
 
-	"github.com/capeprivacy/cli/config"
-
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+
+	"github.com/capeprivacy/cli/config"
+	"github.com/capeprivacy/cli/render"
 )
 
 var C config.Config
@@ -36,7 +37,9 @@ var rootCmd = &cobra.Command{
 			return err
 		}
 
-		log.SetFormatter(formatterFromString(o))
+		setRenderer(cmd, o)
+
+		log.SetFormatter(&PlainFormatter{})
 
 		v, err := cmd.Flags().GetBool("verbose")
 		if err != nil {
@@ -183,22 +186,29 @@ func initConfig() {
 	}
 }
 
-func formatterFromString(s string) log.Formatter {
+func setRenderer(cmd *cobra.Command, s string) {
+	ctx := cmd.Context()
+
+	var r render.Renderer
+	r = render.Print{}
 	switch s {
 	case "json":
-		return &log.JSONFormatter{}
-	case "log":
-		return &log.TextFormatter{}
-	case "log_plain":
-		return &log.TextFormatter{
-			DisableColors: true,
-			FullTimestamp: true,
-		}
-	case "plain":
+		r = &render.JSON{}
+	case "human":
 		fallthrough
 	default:
-		return &PlainFormatter{}
+		if t, ok := tmpl[cmd.Name()]; ok {
+			r = render.NewTemplate(t)
+		}
 	}
+
+	cmd.SetContext(render.WithCtx(ctx, r))
+}
+
+var tmpl = make(map[string]string)
+
+func registerTemplate(name, template string) {
+	tmpl[name] = template
 }
 
 var readConfFile = viper.ReadInConfig

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/lestrrat-go/jwx/v2 v2.0.6
 	github.com/lithammer/shortuuid/v4 v4.0.0
 	github.com/pkg/errors v0.9.1
-	github.com/spf13/cobra v1.4.0
+	github.com/spf13/cobra v1.5.0
 	golang.org/x/text v0.3.7
 )
 

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,7 @@ github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGX
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -254,6 +255,8 @@ github.com/spf13/cast v1.4.1 h1:s0hze+J0196ZfEMTs80N7UlFt0BDuQ7Q+JDnHiMWKdA=
 github.com/spf13/cast v1.4.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v1.4.0 h1:y+wJpx64xcgO1V+RcnwW0LEHxTKRi2ZDPSBjWnrg88Q=
 github.com/spf13/cobra v1.4.0/go.mod h1:Wo4iy3BUC+X2Fybo0PDqwJIv3dNRiZLHQymsfxlB84g=
+github.com/spf13/cobra v1.5.0 h1:X+jTBEBqF0bHN+9cSMgmfuvv2VHJ9ezmFNf9Y/XstYU=
+github.com/spf13/cobra v1.5.0/go.mod h1:dWXEIy2H428czQCjInthrTRUg7yKbok+2Qi/yBIJoUM=
 github.com/spf13/jwalterweatherman v1.1.0 h1:ue6voC5bR5F8YxI5S67j9i582FU4Qvo2bmqnqMYADFk=
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=

--- a/render/context.go
+++ b/render/context.go
@@ -1,0 +1,24 @@
+package render
+
+import "context"
+
+type ctxKey struct{}
+
+// WithCtx returns a copy of ctx with r associated.
+func WithCtx(ctx context.Context, r Renderer) context.Context {
+	return context.WithValue(ctx, ctxKey{}, r)
+}
+
+// Ctx returns the Renderer associated with the ctx. If no logger
+// is associated, DefaultContextRenderer is returned, unless DefaultContextRenderer
+// is nil, in which case a Print renderer is returned.
+func Ctx(ctx context.Context) Renderer {
+	if r, ok := ctx.Value(ctxKey{}).(Renderer); ok {
+		return r
+	} else if r = DefaultContextRenderer; r != nil {
+		return r
+	}
+	return Print{}
+}
+
+var DefaultContextRenderer Renderer

--- a/render/context_test.go
+++ b/render/context_test.go
@@ -1,0 +1,33 @@
+package render
+
+import (
+	"context"
+	"testing"
+)
+
+func TestWithCtx(t *testing.T) {
+	r := NewTemplate("foo")
+	ctx := WithCtx(context.Background(), r)
+	r2 := Ctx(ctx)
+	if got, want := r2, r; got != want {
+		t.Errorf("Ctx returned incorrect Renderer;\n\tgot  %#v\n\twant %#v", got, want)
+	}
+}
+
+func TestWithCtxDefault(t *testing.T) {
+	r := Print{}
+	r2 := Ctx(context.Background())
+	if got, want := r2, r; got != want {
+		t.Errorf("Ctx returned incorrect Renderer;\n\tgot  %#v\n\twant %#v", got, want)
+	}
+}
+
+func TestWithCtxDefaultContextRenderer(t *testing.T) {
+	r := NewTemplate("itsa me")
+	DefaultContextRenderer = r
+
+	r2 := Ctx(context.Background())
+	if got, want := r2, r; got != want {
+		t.Errorf("Ctx returned incorrect Renderer;\n\tgot  %#v\n\twant %#v", got, want)
+	}
+}

--- a/render/render.go
+++ b/render/render.go
@@ -1,0 +1,63 @@
+package render
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"text/template"
+)
+
+// A Render formats the provided value and outputs it to the writer.
+type Renderer interface {
+	Render(w io.Writer, value any) error
+}
+
+// MustRender calls `r.Render()` and panics if a non-nil error is returned
+func MustRender(r Renderer, w io.Writer, value any) {
+	if err := r.Render(w, value); err != nil {
+		panic(err)
+	}
+}
+
+// JSON is a renderers that marshals the value to JSON
+type JSON struct{}
+
+// Render implements the Renderer interface
+func (j JSON) Render(w io.Writer, value any) error {
+	return json.NewEncoder(w).Encode(value)
+}
+
+// Print prints the value with the default format for the value's type.
+type Print struct{}
+
+// Render implements the Renderer interface
+func (p Print) Render(w io.Writer, value any) error {
+	_, err := fmt.Fprint(w, value)
+	return err
+}
+
+// Template renders a template with the provided value
+type Template struct {
+	tmpl string
+}
+
+// NewTemplate creates a Template with the given string template
+func NewTemplate(tmpl string) *Template {
+	return &Template{
+		tmpl: tmpl,
+	}
+}
+
+// Render implements the Renderer interface
+func (t *Template) Render(w io.Writer, value any) error {
+	tmpl, err := template.New("tmpl").Parse(t.tmpl)
+	if err != nil {
+		return fmt.Errorf("invalid template: %w", err)
+	}
+
+	if err = tmpl.Execute(w, value); err != nil {
+		return fmt.Errorf("error rendering template: %w", err)
+	}
+
+	return nil
+}

--- a/render/render_test.go
+++ b/render/render_test.go
@@ -1,0 +1,127 @@
+package render
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+	"text/template"
+)
+
+func TestRender(t *testing.T) {
+	tests := []struct {
+		name string
+		r    Renderer
+		in   any
+		out  string
+	}{
+		{
+			name: "JSON - struct",
+			r:    &JSON{},
+			in: struct {
+				Foo string `json:"foo"`
+				Bar string `json:"bar"`
+			}{
+				Foo: "I'm foo!",
+				Bar: "And I'm bar!",
+			},
+			out: `{"foo":"I'm foo!","bar":"And I'm bar!"}
+`,
+		},
+		{
+			name: "JSON - map",
+			r:    &JSON{},
+			in: map[string]string{
+				"foo": "I'm foo!",
+				"bar": "And I'm bar!",
+			},
+			out: `{"bar":"And I'm bar!","foo":"I'm foo!"}
+`,
+		},
+		{
+			name: "Print",
+			r:    Print{},
+			in: map[string]string{
+				"foo": "I'm foo!",
+				"bar": "And I'm bar!",
+			},
+			out: "map[bar:And I'm bar! foo:I'm foo!]",
+		},
+		{
+			name: "Template",
+			r:    NewTemplate("Foo: {{ .Foo }} - Bar: {{ .Bar }}"),
+			in: struct {
+				Foo string `json:"foo"`
+				Bar string `json:"bar"`
+			}{
+				Foo: "I'm foo!",
+				Bar: "And I'm bar!",
+			},
+			out: "Foo: I'm foo! - Bar: And I'm bar!",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var buf strings.Builder
+			MustRender(test.r, &buf, test.in)
+			if got, want := buf.String(), test.out; got != want {
+				t.Errorf("value rendered incorrectly: got %q want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestTemplateErr(t *testing.T) {
+	tests := []struct {
+		name string
+		r    Renderer
+		in   any
+		out  error
+	}{
+		{
+			name: "bad template",
+			r:    NewTemplate("{{ {{ }}"),
+			in:   map[string]string{"does_not_matter": "it's a no-op"},
+			out:  fmt.Errorf("invalid template: %w", errors.New("template: tmpl:1: unexpected \"{\" in command")),
+		},
+		{
+			name: "failed to render",
+			r:    NewTemplate("{{ .NotAField }}"),
+			in: struct {
+				AField string
+			}{
+				AField: "further afield",
+			},
+			out: fmt.Errorf(
+				"error rendering template: %w",
+				template.ExecError{
+					Name: "tmpl",
+					Err:  errors.New("template: tmpl:1:3: executing \"tmpl\" at <.NotAField>: can't evaluate field NotAField in type struct { AField string }"),
+				},
+			),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var buf strings.Builder
+			if got, want := test.r.Render(&buf, test.in), test.out; !reflect.DeepEqual(got, want) {
+				t.Errorf("unexpected error returned;\n\tgot  %#v\n\twant %#v", got, want)
+			}
+		})
+	}
+}
+
+func TestPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("MustRender did not panic")
+		}
+	}()
+
+	r := NewTemplate("{{ {{ }}")
+	var buf strings.Builder
+	MustRender(r, &buf, map[string]string{"spooky": "season"})
+}


### PR DESCRIPTION
Introduces a render package with a Renderer interface for formatting command
output. Provides a JSON renderer, a text-template renderer, and a print
renderer, as well as management for passing a renderer via a context.Context.

The new renderer is configured by the global `-o` flag, replacing it's old
behavior. Logging statements are no longer affected by the flag. Currently,
only the deploy command uses the flag for output.
