### PR TITLE
Add json output to token cmd

### DIFF
--- a/cmd/cape/cmd/token.go
+++ b/cmd/cape/cmd/token.go
@@ -13,10 +13,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/capeprivacy/cli/render"
 	"github.com/lestrrat-go/jwx/v2/jwa"
 	"github.com/lestrrat-go/jwx/v2/jwt"
 	"github.com/spf13/cobra"
+
+	"github.com/capeprivacy/cli/render"
 )
 
 var privateKeyFile = "token.pem"
@@ -94,7 +95,7 @@ func token(cmd *cobra.Command, args []string) error {
 		Checksum string `json:"function_checksum"`
 	}{
 		ID:       functionID,
-		Token:   tokenString,
+		Token:    tokenString,
 		Checksum: functionChecksum,
 	}
 

--- a/cmd/cape/cmd/token.go
+++ b/cmd/cape/cmd/token.go
@@ -95,7 +95,7 @@ func token(cmd *cobra.Command, args []string) error {
 	}{
 		ID:       functionID,
 		Token:    fmt.Sprintf("%x", tokenString),
-		Checksum: functionCheksum,
+		Checksum: functionChecksum,
 	}
 
 	return render.Ctx(cmd.Context()).Render(cmd.OutOrStdout(), output)

--- a/cmd/cape/cmd/token.go
+++ b/cmd/cape/cmd/token.go
@@ -33,7 +33,7 @@ func init() {
 
 	tokenCmd.PersistentFlags().IntP("expires", "e", 3600, "optional time to live (in seconds)")
 	tokenCmd.PersistentFlags().BoolP("owner", "", false, "optional owner token (debug logs)")
-	tokenCmd.PersistentFlags().StringP("function_checksum", "", "", "optional function checksum")
+	tokenCmd.PersistentFlags().StringP("function-checksum", "", "", "optional function checksum")
 
 	registerTemplate(tokenCmd.Name(), tokenTmpl)
 }
@@ -59,7 +59,12 @@ func token(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	functionCheksum, err := cmd.Flags().GetString("function_checksum")
+	functionCheksum, err := cmd.Flags().GetString("function-checksum")
+	if err != nil {
+		return err
+	}
+
+	o, err := cmd.Flags().GetString("output")
 	if err != nil {
 		return err
 	}
@@ -74,6 +79,13 @@ func token(cmd *cobra.Command, args []string) error {
 	tokenString, err := Token(issuer, functionID, expires, owner)
 	if err != nil {
 		return err
+	}
+
+	if o != "json" {
+		_, err = cmd.OutOrStdout().Write([]byte(tokenString + "\n"))
+		if err != nil {
+			return err
+		}
 	}
 
 	output := struct {
@@ -222,6 +234,4 @@ func generateKeyPair() error {
 	return nil
 }
 
-var tokenTmpl = `Success! Function token generated for function ID {{ .ID }}.
-Function token ➜ {{ .Token }} 
-`
+var tokenTmpl = ``

--- a/cmd/cape/cmd/token.go
+++ b/cmd/cape/cmd/token.go
@@ -222,4 +222,4 @@ func generateKeyPair() error {
 	return nil
 }
 
-var tokenTmpl = `{{ .Token }}\n`
+var tokenTmpl = "{{ .Token }}\n"

--- a/cmd/cape/cmd/token.go
+++ b/cmd/cape/cmd/token.go
@@ -65,11 +65,6 @@ func token(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	o, err := cmd.Flags().GetString("output")
-	if err != nil {
-		return err
-	}
-
 	// Use the AccessToken sub (user id) as the issuer for the function token.
 	// The issuer is used to determine which KMS key to use inside the enclave.
 	issuer := accessTokenParsed.Subject()
@@ -80,13 +75,6 @@ func token(cmd *cobra.Command, args []string) error {
 	tokenString, err := Token(issuer, functionID, expires, owner)
 	if err != nil {
 		return err
-	}
-
-	if o != "json" {
-		_, err = cmd.OutOrStdout().Write([]byte(tokenString + "\n"))
-		if err != nil {
-			return err
-		}
 	}
 
 	output := struct {
@@ -234,4 +222,4 @@ func generateKeyPair() error {
 	return nil
 }
 
-var tokenTmpl = ``
+var tokenTmpl = `{{ .Token }}\n`

--- a/cmd/cape/cmd/token.go
+++ b/cmd/cape/cmd/token.go
@@ -94,7 +94,7 @@ func token(cmd *cobra.Command, args []string) error {
 		Checksum string `json:"function_checksum"`
 	}{
 		ID:       functionID,
-		Token:    fmt.Sprintf("%x", tokenString),
+		Token:   tokenString,
 		Checksum: functionChecksum,
 	}
 

--- a/cmd/cape/cmd/token.go
+++ b/cmd/cape/cmd/token.go
@@ -99,7 +99,6 @@ func token(cmd *cobra.Command, args []string) error {
 	}
 
 	return render.Ctx(cmd.Context()).Render(cmd.OutOrStdout(), output)
-
 }
 
 func Token(issuer string, functionID string, expires int, owner bool) (string, error) {

--- a/cmd/cape/cmd/token.go
+++ b/cmd/cape/cmd/token.go
@@ -59,7 +59,7 @@ func token(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	functionCheksum, err := cmd.Flags().GetString("function-checksum")
+	functionChecksum, err := cmd.Flags().GetString("function-checksum")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR is a follow up on https://github.com/capeprivacy/cli/pull/194. It will be rebased once https://github.com/capeprivacy/cli/pull/194 is merged. This PR add the option to render the output as a JSON. It also adds `function_cheksum` an optional argument so the JSON output can hold a function ID, function token and function checksum  which can be used later by SDKs to run a function.