### PR TITLE
Print the function name after a deploy

### DIFF
--- a/cmd/cape/cmd/deploy.go
+++ b/cmd/cape/cmd/deploy.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/lestrrat-go/jwx/v2/jwt"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
@@ -99,12 +100,25 @@ func deploy(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	username, err := getUsername()
+	if err != nil {
+		return err
+	}
+
+	// older tokens might not have a username, in that case, we just won't tell them the function alias
+	functionName := ""
+	if username != "" {
+		functionName = fmt.Sprintf("%s/%s", username, name)
+	}
+
 	output := struct {
-		ID       string `json:"function_id"`
-		Checksum string `json:"function_checksum"`
+		ID           string `json:"function_id"`
+		Checksum     string `json:"function_checksum"`
+		FunctionName string `json:"function_name,omitempty"`
 	}{
-		ID:       dID,
-		Checksum: fmt.Sprintf("%x", checksum),
+		ID:           dID,
+		Checksum:     fmt.Sprintf("%x", checksum),
+		FunctionName: functionName,
 	}
 
 	return render.Ctx(cmd.Context()).Render(cmd.OutOrStdout(), output)
@@ -244,6 +258,20 @@ func zipSize(path string) (uint64, error) {
 	return size, nil
 }
 
+func getUsername() (string, error) {
+	t, err := getAuthToken()
+	if err != nil {
+		return "", err
+	}
+
+	token, err := jwt.Parse([]byte(t), jwt.WithVerify(false))
+	if err != nil {
+		return "", err
+	}
+
+	return token.PrivateClaims()["https://capeprivacy.com/username"].(string), nil
+}
+
 func getAuthToken() (string, error) {
 	tokenResponse, err := getTokenResponse()
 	if err != nil {
@@ -326,7 +354,7 @@ func getFunctionTokenPublicKey() (string, error) {
 	return pem.String(), nil
 }
 
-var deployTmpl = `Success! Deployed function to Cape.
-Function ID ➜  {{ .ID }}
+var deployTmpl = `Function ID       ➜  {{ .ID }}
 Function Checksum ➜  {{ .Checksum }}
+Function Name     ➜  {{ .FunctionName }} 
 `


### PR DESCRIPTION
E.g.,

```
$ cape deploy isprime
Deploying function to Cape ...
Function ID       ➜  K9JVrVQpWeRq24D4JRDAuz
Function Checksum ➜  66731e5ccf226680dd5c98a1d1ad52b7a4c986984042d0672d8f3153130b34a8
Function Name     ➜  bendecoste/isprime
```