### PR TITLE
Improve error reporting when running function by alias fails

### DIFF
--- a/sdk/function_id.go
+++ b/sdk/function_id.go
@@ -55,6 +55,10 @@ func GetFunctionID(functionReq FunctionIDRequest) (string, error) {
 	}
 
 	if res.StatusCode != http.StatusOK {
+		if res.StatusCode == http.StatusBadGateway {
+			return "", fmt.Errorf("could not lookup function, received %d from server", res.StatusCode)
+		}
+
 		// return the error message from supervisor
 		var e errorMsg
 		err = json.Unmarshal(body, &e)


### PR DESCRIPTION
The dev environment I am testing against is failing to lookup a function alias (e.g,. `bendecoste/isprime`), and the error message I see on the CLI is not the best

```
$ cape run bendecoste/isprime 45 --url $CAPE_URL --insecure
Error: error retrieving function id: error retrieving function: couldn't unmarshal json
Usage:
  cape run { <function_id> | <user_name>/<function_name> } [input data] [flags]

Examples:

	# Run a function named 'echo' created by user 'capedocs'
	$ cape run capedocs/echo 'Hello World'

	# Run a function with input data provided on stdin
	$ echo '1234' | cape run capedocs/echo -f -

	# Filter a function's output through sed
	$ cape run capedocs/echo 'Hello World' | sed 's/Hello/Hola/'

Flags:
  -f, --file string                  input data file (or '-f -' to accept stdin)
      --function-checksum string     function checksum to attest
  -h, --help                         help for run
      --key-policy-checksum string   key policy checksum to attest
  -p, --pcr strings                  pass multiple PCRs to validate against
  -t, --token string                 function token to use

Global Flags:
  -c, --config string   config file (default "$HOME/.config/cape/presets.json")
  -o, --output string   output format (default "plain")
  -v, --verbose         verbose output

Command failed with error.
```

After looking into this, it seems that looking up the function ID is producing a 502 error with an HTML response. Which explains the unable to unmarshall JSON message. In the case of 502, I have changed the error message to indicate that we are seeing a 502, and not even trying to unmarshall.

This now looks like

```
$ cape run bendecoste/isprime 45 --url $CAPE_URL --insecure
Error: error retrieving function id: could not lookup function, received 502 from server
```

However, it was also still showing the Usage info. Since this is not a user error, we shouldn't do that.

I have introduced a new error type when looking up the function ID to handle that

The final error experience now looks like

```
$ cape run bendecoste/isprime 45 --url $CAPE_URL --insecure
Error: could not lookup function, received 502 from server
Command failed with error.
```