### PR TITLE
Close websocket and remove deprecated stdlib calls

### DIFF
--- a/cmd/cape/cmd/list.go
+++ b/cmd/cape/cmd/list.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 
@@ -73,7 +73,7 @@ func doList(url string, insecure bool, auth entities.FunctionAuth) error { //nol
 		return fmt.Errorf("expected 200, got server response code %d", res.StatusCode)
 	}
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return errors.New("could not read response body")
 	}

--- a/sdk/deploy.go
+++ b/sdk/deploy.go
@@ -51,7 +51,10 @@ func Deploy(req DeployRequest, keyReq KeyRequest) (string, []byte, error) {
 	if err != nil {
 		return "", nil, err
 	}
-	defer conn.Close()
+	defer func() {
+		_ = conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+		conn.Close()
+	}()
 
 	p := getProtocol(conn)
 

--- a/sdk/function_id.go
+++ b/sdk/function_id.go
@@ -3,7 +3,7 @@ package sdk
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/pkg/errors"
@@ -49,7 +49,7 @@ func GetFunctionID(functionReq FunctionIDRequest) (string, error) {
 		return "", fmt.Errorf("failed to receive functionID %w", err)
 	}
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return "", errors.New("could not read response body")
 	}

--- a/sdk/run.go
+++ b/sdk/run.go
@@ -33,7 +33,10 @@ func Run(req RunRequest) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer conn.Close()
+	defer func() {
+		_ = conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+		conn.Close()
+	}()
 	return invoke(doc, conn, req.Data)
 }
 

--- a/sdk/test.go
+++ b/sdk/test.go
@@ -37,7 +37,10 @@ func Test(testReq TestRequest, endpoint string, pcrSlice []string) (*entities.Ru
 	if err != nil {
 		return nil, err
 	}
-	defer conn.Close()
+	defer func() {
+		_ = conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+		conn.Close()
+	}()
 
 	nonce, err := crypto.GetNonce()
 	if err != nil {


### PR DESCRIPTION
Sends close message before closing websocket to indicate to the server
that the client is shutting down normally. Also removes uses of
deprecated ioutil.ReadAll which was deprecated in go1.16.
