### PR TITLE
Remove log and update error messages

### DIFF
--- a/cmd/cape/cmd/run.go
+++ b/cmd/cape/cmd/run.go
@@ -209,7 +209,7 @@ func run(cmd *cobra.Command, args []string) error {
 		FunctionAuth: auth,
 	})
 	if err != nil {
-		return fmt.Errorf("error processing data: %w", err)
+		return fmt.Errorf("run request failed: %w", err)
 	}
 
 	fmt.Println(string(results))
@@ -233,7 +233,7 @@ func Run(url string, auth entities.FunctionAuth, functionID string, file string,
 		FunctionAuth: auth,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("error processing data: %w", err)
+		return nil, fmt.Errorf("run request failed: %w", err)
 	}
 
 	return res, nil

--- a/sdk/deploy.go
+++ b/sdk/deploy.go
@@ -71,7 +71,6 @@ func Deploy(req DeployRequest, keyReq KeyRequest) (string, []byte, error) {
 
 	attestDoc, err := p.ReadAttestationDoc()
 	if err != nil {
-		log.Error("error reading attestation doc")
 		return "", nil, err
 	}
 

--- a/sdk/key.go
+++ b/sdk/key.go
@@ -96,7 +96,6 @@ func ConnectAndAttest(keyReq KeyRequest) (*attest.AttestationDoc, *attest.Attest
 
 	attestDoc, err := p.ReadAttestationDoc()
 	if err != nil {
-		log.Println("error reading attestation doc")
 		return nil, nil, err
 	}
 

--- a/sdk/run.go
+++ b/sdk/run.go
@@ -69,7 +69,6 @@ func connect(url string, functionID string, functionAuth entities.FunctionAuth, 
 
 	attestDoc, err := p.ReadAttestationDoc()
 	if err != nil {
-		log.Println("error reading attestation doc")
 		return nil, nil, err
 	}
 


### PR DESCRIPTION
Removes the "error reading attestation doc" logs. The failures that
resulted in that log being output could be from things like failing to
download a function, or checksum mismatch, among other things, so this
message was technically accurate but often quite misleading. The actual
error returned from the function is also logged, and this is often much
more helpful in understanding what went wrong.

Also updates the error message when a call to sdk.Run() fails to better
reflect what happened.
