### PR TITLE
Add pagination to cape list

### DIFF
--- a/cmd/cape/cmd/list.go
+++ b/cmd/cape/cmd/list.go
@@ -57,7 +57,7 @@ func list(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	auth := entities.FunctionAuth{Type: entities.AuthenticationTypeAuth0, Token: t}
-	err = doList(u, insecure, auth, offset, limit)
+	err = doList(u, insecure, auth, limit, offset)
 	if err != nil {
 		return fmt.Errorf("list failed: %w", err)
 	}


### PR DESCRIPTION
Close [CAPE-1071](https://capeprivacy.atlassian.net/browse/CAPE-1071?atlOrigin=eyJpIjoiOGRkZDZiN2I4NTNmNGI3OGIyODk3NTcxNDg4OTJjZmYiLCJwIjoiaiJ9)

This PR add pagination to `cape list`. Currently, without pagination will return all the functions deployed which can be potentially a lot. Pagination can be controlled with a `limit` and `offset` parameter. As a following step to improving the user experience we could potentially look into something like [bubble list](https://github.com/charmbracelet/bubbles#list)
