### PR TITLE
improve timezone formatting when listing functions

### DIFF
--- a/cmd/cape/cmd/list.go
+++ b/cmd/cape/cmd/list.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/spf13/cobra"
@@ -123,8 +124,13 @@ func doList(url string, insecure bool, auth entities.FunctionAuth, limit int, of
 	t := table.NewWriter()
 	t.SetOutputMirror(os.Stdout)
 	t.AppendHeader(table.Row{"#", "Name", "ID", "Created At"})
+	localTime, err := time.LoadLocation("Local")
+	if err != nil {
+		return err
+	}
+
 	for i, deployment := range deploymentNames {
-		t.AppendRow([]interface{}{i, deployment.Name, deployment.ID, deployment.CreatedAt})
+		t.AppendRow([]interface{}{i, deployment.Name, deployment.ID, deployment.CreatedAt.In(localTime).Format("Jan 02 2006 15:04")})
 	}
 	t.SetStyle(table.StyleLight)
 	t.Render()


### PR DESCRIPTION
previously, output looked like

```
┌────┬────────────────────┬────────────────────────┬──────────────────────────────────────┐
│  # │ NAME               │ ID                     │ CREATED AT                           │
├────┼────────────────────┼────────────────────────┼──────────────────────────────────────┤
│  0 │ heatmap            │ R4WzjhvTb4AKUerHcXUi3G │ 2022-11-24 00:28:41.11527 +0000 UTC  │
│  1 │ heatmap            │ bcCZgR4gmcQCb2LLCFKAnJ │ 2022-11-24 00:20:51.658571 +0000 UTC │
└────┴────────────────────┴────────────────────────┴──────────────────────────────────────┘
```

I have converted these times to the local timezone, and made them more human readable

```
┌────┬────────────────────┬────────────────────────┬───────────────────┐
│  # │ NAME               │ ID                     │ CREATED AT        │
├────┼────────────────────┼────────────────────────┼───────────────────┤
│  0 │ isprime            │ i456Dypid3VSApqMU8NYpY │ Nov 24 2022 10:40 │
│  1 │ heatmap            │ R4WzjhvTb4AKUerHcXUi3G │ Nov 23 2022 20:28 │
│  2 │ heatmap            │ bcCZgR4gmcQCb2LLCFKAnJ │ Nov 23 2022 20:20 │
└────┴────────────────────┴────────────────────────┴───────────────────┘
```