### PR TITLE
Add better description around usage for PCR verification

### DIFF
--- a/cmd/cape/cmd/pcrs.go
+++ b/cmd/cape/cmd/pcrs.go
@@ -22,7 +22,8 @@ var getPCRsCmd = &cobra.Command{
 The PCRs are measurements of the executable version of the cape
 runtime that processes requests. These PCRs can be supplied to
 other commands to validate that Cape is running a version of the
-code that you've verified.`,
+code that you've verified. This command takes a while to run as it
+requires downloading of the latest runtime version.`,
 	RunE: getPCRs,
 }
 

--- a/cmd/cape/cmd/run.go
+++ b/cmd/cape/cmd/run.go
@@ -34,6 +34,11 @@ Results are output to stdout so you can easily pipe them elsewhere.`,
 
 	# Filter a function's output through sed
 	$ cape run capedocs/echo 'Hello World' | sed 's/Hello/Hola/'
+
+	# Run while verifying PCRs
+	# PCRs can be retrieved with: 'cape get-pcrs'
+	# PCRs are specified through a string array of the form: [<PCR_number>:<PCR_value>], example below
+	$ cape run capedocs/echo 5 --pcr=0:placeholderPCR0,8:placeholderPCR8
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		err := run(cmd, args)

--- a/pcrs/pcrs.go
+++ b/pcrs/pcrs.go
@@ -18,6 +18,14 @@ import (
 	"github.com/capeprivacy/attest/attest"
 )
 
+type InvalidPCRValueError struct {
+	Key string
+}
+
+func (i InvalidPCRValueError) Error() string {
+	return fmt.Sprintf("unable to parse PCR number for input: %s, please specify numeric PCR number", i.Key)
+}
+
 type Measurements map[string]string
 
 type EIFInfo struct {
@@ -75,7 +83,7 @@ func VerifyPCRs(pcrs map[string][]string, doc *attest.AttestationDoc) error {
 	for key, values := range pcrs {
 		pcrIndex, err := strconv.Atoi(key)
 		if err != nil {
-			return err
+			return InvalidPCRValueError{Key: key}
 		}
 		h := hex.EncodeToString(doc.PCRs[pcrIndex])
 


### PR DESCRIPTION
Adds usage prompts on how to specify PCR verification during run. Also improves error message in case of bad user input. 
Updates get-pcr description since the command takes a while downloading the eif we run. 

Output after change: 
```
Usage:
  cape run { <function_id> | <user_name>/<function_name> } [input data] [flags]

Examples:

        # Run a function named 'echo' created by user 'capedocs'
        $ cape run capedocs/echo 'Hello World'

        # Run a function with input data provided on stdin
        $ echo '1234' | cape run capedocs/echo -f -

        # Filter a function's output through sed
        $ cape run capedocs/echo 'Hello World' | sed 's/Hello/Hola/'

        # Run while verifying PCRs
        # PCRs can be retrieved with: 'cape get-pcrs'
        # PCRs are specified through a string array of the form: [<PCR_number>:<PCR_value>], example below
        $ cape run capedocs/echo 5 --pcr=0:placeholderPCR0,8:placeholderPCR8
```

```
cape run 2gmRaLYNGE4gzaMe8s6Wgd  5 --pcr=8:6f1ff0f2a7a0b1c4e02a3a544eb0ff2dffb8b2922b8908d46365c0f0120934092149ec35814c8d944ef1b8fb564b46c7,hi:6f1ff0f2a7a0b1c4e02a3a544eb0ff2dffb8b2922b8908d46365c0f0120934092149ec35814c8d944ef1b8fb564b46c7
error verifying PCRs
Error: run request failed: unable to parse PCR number due to: strconv.Atoi: parsing "hi": invalid syntax, please specify numeric PCR number
Command failed with error.
```