### PR TITLE
Improve output for unauthorized error

### DIFF
--- a/cmd/cape/cmd/root.go
+++ b/cmd/cape/cmd/root.go
@@ -69,7 +69,6 @@ var rootCmd = &cobra.Command{
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func ExecuteCLI() {
 	if rootCmd.Execute() != nil {
-		fmt.Println("Command failed with error.")
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Improves the output when the list command receives a 401. The error
message no longer references the http status code, and instead
indicates to the user that authentication is required. Also removes
the unhelpful "Command failed with error." message.
