### PR TITLE
check to see if there is a new version of cli

### DIFF
--- a/cmd/cape/cmd/version.go
+++ b/cmd/cape/cmd/version.go
@@ -7,42 +7,44 @@ import (
 	"github.com/spf13/cobra"
 )
 
+func getVersion() string {
+	if version != "unknown" {
+		return version
+	}
+
+	if bi, ok := debug.ReadBuildInfo(); ok {
+		var vcs struct {
+			sys string
+			rev string
+		}
+		for _, setting := range bi.Settings {
+			switch setting.Key {
+			case "vcs":
+				vcs.sys = setting.Value
+			case "vcs.revision":
+				vcs.rev = fmt.Sprintf("%.7s", setting.Value)
+			case "vcs.modified":
+				if setting.Value == "true" {
+					vcs.rev = fmt.Sprintf("%s-dirty", vcs.rev)
+				}
+			}
+		}
+		if vcs.sys != "" {
+			return fmt.Sprintf("%s vcs: %s:%s\n", bi.Main.Version, vcs.sys, vcs.rev)
+		}
+
+		return fmt.Sprintf(bi.Main.Version)
+	}
+
+	return "unknown"
+}
+
 // versionCmd represents the version command
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Show cape version",
 	Run: func(cmd *cobra.Command, args []string) {
-		if version != "unknown" {
-			fmt.Println(version)
-			return
-		}
-
-		if bi, ok := debug.ReadBuildInfo(); ok {
-			var vcs struct {
-				sys string
-				rev string
-			}
-			for _, setting := range bi.Settings {
-				switch setting.Key {
-				case "vcs":
-					vcs.sys = setting.Value
-				case "vcs.revision":
-					vcs.rev = fmt.Sprintf("%.7s", setting.Value)
-				case "vcs.modified":
-					if setting.Value == "true" {
-						vcs.rev = fmt.Sprintf("%s-dirty", vcs.rev)
-					}
-				}
-			}
-			if vcs.sys != "" {
-				fmt.Printf("%s vcs: %s:%s\n", bi.Main.Version, vcs.sys, vcs.rev)
-			} else {
-				fmt.Println(bi.Main.Version)
-			}
-			return
-		}
-
-		fmt.Println("unknown")
+		fmt.Println(getVersion())
 	},
 }
 

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/fxamacker/cbor/v2 v2.4.0 // indirect
 	github.com/goccy/go-json v0.9.11 // indirect
 	github.com/google/uuid v1.3.0 // indirect
+	github.com/hashicorp/go-version v1.6.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hf/nsm v0.0.0-20220930140112-cd181bd646b9 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -140,6 +140,8 @@ github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5m
 github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
+github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=

--- a/sdk/encrypt.go
+++ b/sdk/encrypt.go
@@ -79,12 +79,7 @@ func Encrypt(message, username string, options ...Option) (string, error) {
 		return "", errors.New("error parsing attestation document")
 	}
 
-	root, err := attest.GetRootAWSCert()
-	if err != nil {
-		return "", err
-	}
-
-	doc, err := attest.Attest(r.AttestationDocument, nil, root)
+	doc, err := attest.Attest(r.AttestationDocument, nil, nil)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
It looks like this ...

```
cape deploy isprime
Deploying function to Cape ...
Function ID       ➜  iaHGcKFr532kkZmUmAyFQt
Function Checksum ➜  66731e5ccf226680dd5c98a1d1ad52b7a4c986984042d0672d8f3153130b34a8
Function Name     ➜  bendecoste/isprime 

There is a new version (v0.4.4) of the Cape CLI available, you can download it at https://github.com/capeprivacy/cli/releases/latest
Or upgrade by running 
        curl -fsSL https://raw.githubusercontent.com/capeprivacy/cli/main/install.sh | sh
```

