### PR TITLE
Token Tweaks

### DIFF
--- a/cmd/cape/cmd/login.go
+++ b/cmd/cape/cmd/login.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -14,13 +13,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/lestrrat-go/jwx/v2/jwk"
-
 	"github.com/capeprivacy/cli/sdk"
 
 	"github.com/avast/retry-go"
-	"github.com/lestrrat-go/jwx/v2/jwt"
-
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -216,20 +211,6 @@ func getTokenResponse() (*TokenResponse, error) {
 
 	return &response, nil
 }
-
-func defaultGetAccessTokenVerifyAndParse() (jwt.Token, error) {
-	tokenResponse, err := getTokenResponse()
-	if err != nil {
-		return nil, err
-	}
-	set, err := jwk.Fetch(context.Background(), fmt.Sprintf("%s/.well-known/jwks.json", C.AuthHost))
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse JWKS %w", err)
-	}
-	return jwt.Parse([]byte(tokenResponse.AccessToken), jwt.WithKeySet(set))
-}
-
-var getAccessTokenVerifyAndParse = defaultGetAccessTokenVerifyAndParse
 
 // Based on GIST: https://gist.github.com/hyg/9c4afcd91fe24316cbf0
 func openbrowser(url string) error {

--- a/cmd/cape/cmd/token.go
+++ b/cmd/cape/cmd/token.go
@@ -246,7 +246,7 @@ you pass a function id with --function flag and then this token can only be used
 			return err
 		}
 
-		if _, err := cmd.OutOrStdout().Write([]byte(fmt.Sprintf("Success! Your token: %s", tokenResponse.Token))); err != nil {
+		if _, err := cmd.OutOrStdout().Write([]byte(tokenResponse.Token + "\n")); err != nil {
 			return err
 		}
 

--- a/cmd/cape/cmd/token.go
+++ b/cmd/cape/cmd/token.go
@@ -136,10 +136,20 @@ This will be fixed in the future.`,
 var createCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create a token for your account",
-	Long: `Create a token for your account.
+	Long: `Cape Token Create
 
-Use this command if you want a token that identifies you and scoped to a specific function. During creation
-you pass a function id with --function flag and then this token can only be used to run that function.`,
+Create a Personal Access Token (PAT) that uniquely identifies you.
+Currently, tokens can only be used to perform cape run.
+
+By default, a token is able to run any function that its creator is allowed to run and they do not expire.
+You can scope a token to an individual function with the --function flag.
+You can set an expiry of the token with the --expiry flag.
+`,
+	Example: `  cape token create -n my-token -d 'for testing'                  Create a token that can run anything
+  cape token create -n my-token -f Nm672nXZQnBe9vL4zedGJb         Create a token that can only run the function Nm672nXZQnBe9vL4zedGJb
+  cape token create -n my-token -e 1h                             Create a token that can run anything that expires in 1 hour
+  cape token create -n my-token -f Nm672nXZQnBe9vL4zedGJb -e 1h   Create a token that can run Nm672nXZQnBe9vL4zedGJb that expires in 1 hour`,
+
 	RunE: func(cmd *cobra.Command, args []string) error {
 		verbose, err := cmd.Flags().GetBool("verbose")
 		if err != nil {

--- a/cmd/cape/cmd/token.go
+++ b/cmd/cape/cmd/token.go
@@ -184,10 +184,6 @@ you pass a function id with --function flag and then this token can only be used
 			return fmt.Errorf("token names must be alphanumeric")
 		}
 
-		if functionID == "" {
-			return fmt.Errorf("function id must be set")
-		}
-
 		url := C.EnclaveHost
 
 		ctr := createTokenReq{

--- a/cmd/cape/cmd/token_test.go
+++ b/cmd/cape/cmd/token_test.go
@@ -1,141 +1,17 @@
 package cmd
 
 import (
-	"crypto/rand"
-	"crypto/rsa"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
-	"path/filepath"
 	"reflect"
 	"testing"
 	"time"
 
-	"github.com/lestrrat-go/jwx/v2/jwa"
-	"github.com/lestrrat-go/jwx/v2/jwt"
-	"github.com/spf13/viper"
-
 	"github.com/capeprivacy/cli/entities"
 )
-
-// `cape token` uses the token subject from the currently logged in cape user.
-// this helper creates a dummy auth file for that purpose.
-func beforeOnce() (string, error) {
-	// We cannot easily validate the JWKS in test as the test access token is self generated.
-	getAccessTokenVerifyAndParse = func() (jwt.Token, error) {
-		tokenResponse, err := getTokenResponse()
-		if err != nil {
-			return nil, err
-		}
-		return jwt.Parse([]byte(tokenResponse.AccessToken), jwt.WithVerify(false))
-	}
-
-	localConfigDir, err := os.MkdirTemp("", "config")
-	if err != nil {
-		return "", err
-	}
-
-	viper.Set("LOCAL_CONFIG_DIR", localConfigDir)
-
-	accessToken, err := jwt.NewBuilder().
-		Subject("github|test-user").
-		IssuedAt(time.Now()).
-		Expiration(time.Now().Add(time.Hour)).
-		Build()
-	if err != nil {
-		return "", err
-	}
-
-	key, err := rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		return "", err
-	}
-
-	accessTokenString, err := jwt.Sign(accessToken, jwt.WithKey(jwa.RS256, key))
-	if err != nil {
-		return "", err
-	}
-
-	tokenResponse, err := json.MarshalIndent(&TokenResponse{
-		AccessToken: string(accessTokenString),
-	}, "", "  ")
-	if err != nil {
-		return "", err
-	}
-
-	err = os.MkdirAll(localConfigDir, os.ModePerm)
-	if err != nil {
-		return "", err
-	}
-
-	err = os.WriteFile(localConfigDir+"/auth", tokenResponse, 0644)
-	if err != nil {
-		return "", err
-	}
-
-	return localConfigDir, nil
-}
-
-func TestToken(t *testing.T) {
-	myID := "5gWto31CNOTI"
-	myName := "test-user"
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		response := testDeployment{
-			ID:   myID,
-			Name: myName,
-		}
-
-		enc := json.NewEncoder(w)
-
-		err := enc.Encode(response)
-		if err != nil {
-			t.Fatal(err)
-		}
-	}))
-	defer srv.Close()
-
-	previousLocalConfigDir := viper.Get("LOCAL_CONFIG_DIR")
-	localConfigDir, err := beforeOnce()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(localConfigDir)
-	defer viper.Set("LOCAL_CONFIG_DIR", previousLocalConfigDir)
-
-	cmd, stdout, _ := getCmd()
-	// Have to set the url explicitly, will break other tests if it relies on
-	// URL.
-	_ = os.Setenv("CAPE_ENCLAVE_HOST", srv.URL)
-	functionID := "5gWto31CNOTI"
-	cmd.SetArgs([]string{"token", functionID})
-
-	if err := cmd.Execute(); err != nil {
-		t.Fatal(err)
-	}
-	tokenOutput, err := jwt.Parse(stdout.Bytes(), jwt.WithVerify(false))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if tokenOutput.Issuer() != "github|test-user" {
-		t.Fatal("incorrect token issuer")
-	}
-
-	if tokenOutput.Subject() != functionID {
-		t.Fatal("incorrect token subject")
-	}
-
-	if _, err := os.Open(filepath.Join(C.LocalConfigDir, publicKeyFile)); err != nil {
-		t.Fatal(err)
-	}
-
-	if _, err := os.Open(filepath.Join(C.LocalConfigDir, privateKeyFile)); err != nil {
-		t.Fatal(err)
-	}
-}
 
 type testDeployment struct {
 	ID                  string    `json:"id"`

--- a/cmd/cape/cmd/token_test.go
+++ b/cmd/cape/cmd/token_test.go
@@ -255,7 +255,7 @@ func TestAcctToken(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if got, want := stdout.String(), "Success! Your token: yourjwtgoeshere"; got != want {
+	if got, want := stdout.String(), "yourjwtgoeshere\n"; got != want {
 		t.Fatalf("didn't get expected output, got %s, wanted %s", got, want)
 	}
 }


### PR DESCRIPTION
This PR does the following ... 

- Make the function ID optional. This is consistent with the UI right now.
- Remove the extra text when creating a token, so that `cape token create` will just print `<token>` rather than `Success! Your token is <token>`.
- Remove the command for function tokens, it is confusing when used in conjunction with PATs, and you can get their behavior with the --function flag
- Add examples to the token create command