### PR TITLE
fix encrypt input error check

### DIFF
--- a/cmd/cape/cmd/encrypt.go
+++ b/cmd/cape/cmd/encrypt.go
@@ -71,7 +71,7 @@ func encrypt(cmd *cobra.Command, args []string) error {
 	}
 
 	input, userError := parseInput(cmd, args)
-	if err != nil {
+	if userError != nil {
 		return userError
 	}
 
@@ -117,10 +117,12 @@ func parseInput(cmd *cobra.Command, args []string) ([]byte, *UserError) {
 	case len(args) == 1:
 		// read input from  command line string
 		input = []byte(args[0])
+		if len(input) == 0 {
+			return nil, &UserError{Msg: "unable to encrypt", Err: errors.New("input is empty")}
+		}
 	default:
 		return nil, &UserError{Msg: "invalid input", Err: errors.New("please provide input as a string, input file or stdin")}
 	}
-
 	return input, nil
 }
 

--- a/cmd/cape/cmd/encrypt_test.go
+++ b/cmd/cape/cmd/encrypt_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/capeprivacy/cli/sdk"
@@ -20,5 +21,18 @@ func TestEncrypt(t *testing.T) {
 
 	if got, want := stdout.String(), "cape:secret\n"; got != want {
 		t.Fatalf("didn't get expected output, got %s, wanted %s", got, want)
+	}
+}
+
+func TestEncryptEmpty(t *testing.T) {
+	capeEncrypt = func(message, username string, options ...sdk.Option) (string, error) {
+		return "cape:secret", nil
+	}
+
+	cmd, _, _ := getCmd()
+	cmd.SetArgs([]string{"encrypt", "", "--username", "bendecoste"})
+	wantErr := UserError{Msg: "unable to encrypt", Err: errors.New("input is empty")}
+	if err := cmd.Execute(); err.Error() != wantErr.Error() {
+		t.Fatalf("expected error: %s", wantErr.Error())
 	}
 }

--- a/cmd/cape/cmd/encrypt_test.go
+++ b/cmd/cape/cmd/encrypt_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/capeprivacy/cli/sdk"
@@ -24,15 +25,32 @@ func TestEncrypt(t *testing.T) {
 	}
 }
 
-func TestEncryptEmpty(t *testing.T) {
-	capeEncrypt = func(message, username string, options ...sdk.Option) (string, error) {
-		return "cape:secret", nil
-	}
-
-	cmd, _, _ := getCmd()
-	cmd.SetArgs([]string{"encrypt", "", "--username", "bendecoste"})
-	wantErr := UserError{Msg: "unable to encrypt", Err: errors.New("input is empty")}
-	if err := cmd.Execute(); err.Error() != wantErr.Error() {
-		t.Fatalf("expected error: %s", wantErr.Error())
+func TestEncryptBadInput(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		args      []string
+		wantError error
+	}{
+		{
+			name:      "empty input",
+			args:      []string{"encrypt", "", "--username", "bendecoste"},
+			wantError: UserError{Msg: "unable to encrypt", Err: errors.New("input is empty")},
+		},
+		{
+			name:      "too many inputs",
+			args:      []string{"encrypt", "", "", "--username", "bendecoste"},
+			wantError: UserError{Msg: "you must pass in only one input data (stdin, string or filename)", Err: fmt.Errorf("invalid number of input arguments")},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			capeEncrypt = func(message, username string, options ...sdk.Option) (string, error) {
+				return "cape:secret", nil
+			}
+			cmd, _, _ := getCmd()
+			cmd.SetArgs(tt.args)
+			if err := cmd.Execute(); err.Error() != tt.wantError.Error() {
+				t.Fatalf("expected error: %s, got: %s", tt.wantError.Error(), err.Error())
+			}
+		})
 	}
 }

--- a/cmd/cape/cmd/encrypt_test.go
+++ b/cmd/cape/cmd/encrypt_test.go
@@ -41,6 +41,16 @@ func TestEncryptBadInput(t *testing.T) {
 			args:      []string{"encrypt", "", "", "--username", "bendecoste"},
 			wantError: UserError{Msg: "you must pass in only one input data (stdin, string or filename)", Err: fmt.Errorf("invalid number of input arguments")},
 		},
+		{
+			name:      "no file input",
+			args:      []string{"encrypt", "-f", "", "--username", "bendecoste"},
+			wantError: UserError{Msg: "invalid input", Err: errors.New("please provide input as a string, input file or stdin")},
+		},
+		{
+			name:      "bad file input",
+			args:      []string{"encrypt", "-f", "nofile.txt", "--username", "bendecoste"},
+			wantError: &UserError{Msg: "unable to read data file", Err: errors.New("open nofile.txt: no such file or directory")},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			capeEncrypt = func(message, username string, options ...sdk.Option) (string, error) {


### PR DESCRIPTION
CAPE-1385 

You can cape encrypt nothing because the error check conditions were wrong. 
