### PR TITLE
Improve logging and error message connecting to enclave

### DIFF
--- a/sdk/test.go
+++ b/sdk/test.go
@@ -184,13 +184,13 @@ func doDial(endpoint string, insecure bool, authProtocolType string, authToken s
 		return nil, customError(res)
 	}
 
-	log.Debug("* Received 307 redirect")
-
 	location, err := res.Location()
 	if err != nil {
 		log.Error("could not get location off header")
 		return nil, err
 	}
+
+	log.WithField("pool_url", location.Host).Debug("* Connecting to enclave")
 
 	conn, res, err = websocketDial(location.String(), insecure, authProtocolType, authToken)
 	if err != nil {
@@ -199,7 +199,7 @@ func doDial(endpoint string, insecure bool, authProtocolType string, authToken s
 			res.Body.Close()
 			return nil, customErr
 		}
-		log.Error("could not dial websocket again after 307 redirect")
+		log.WithError(err).Error("could not connect to enclave")
 		return nil, err
 	}
 


### PR DESCRIPTION
When connecting to an enclave to process a request, for example to run a
function, the API may redirect to a specific enclave pool URL. This
redirect is normal behavior, and is an implementation detail. The
previous logs which referenced the redirect explicitly were not helpful
to an end-user. This change removes references to that redirect code to
make the messages more meaningful to a typical end-user.
