### PR TITLE
Renable cert chain validation when calling key

### DIFF
--- a/cmd/cape/cmd/test.go
+++ b/cmd/cape/cmd/test.go
@@ -12,6 +12,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
+	"github.com/capeprivacy/attest/attest"
 	"github.com/capeprivacy/cli/sdk"
 	czip "github.com/capeprivacy/cli/zip"
 )
@@ -97,7 +98,9 @@ func Test(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	res, err := test(sdk.TestRequest{Function: fnZip, Input: input, AuthToken: token, Insecure: insecure}, u+"/v1/test", pcrSlice)
+	verifier := attest.NewVerifier()
+
+	res, err := test(sdk.TestRequest{Function: fnZip, Input: input, AuthToken: token, Insecure: insecure}, verifier, u+"/v1/test", pcrSlice)
 	if err != nil {
 		return err
 	}

--- a/cmd/cape/cmd/test_test.go
+++ b/cmd/cape/cmd/test_test.go
@@ -83,7 +83,7 @@ func TestServerError(t *testing.T) {
 	cmd.SetArgs([]string{"test", "testdata/my_fn", "hello world"})
 
 	errMsg := "something went wrong"
-	test = func(testReq sdk.TestRequest, endpoint string, pcrSlice []string) (*entities.RunResults, error) {
+	test = func(testReq sdk.TestRequest, verifier sdk.Verifier, endpoint string, pcrSlice []string) (*entities.RunResults, error) {
 		return nil, errors.New(errMsg)
 	}
 	authToken = func() (string, error) {
@@ -114,7 +114,7 @@ func TestSuccess(t *testing.T) {
 	results := "success!"
 	var gotFn []byte
 	var gotInput []byte
-	test = func(testReq sdk.TestRequest, endpoint string, pcrSlice []string) (*entities.RunResults, error) {
+	test = func(testReq sdk.TestRequest, verifier sdk.Verifier, endpoint string, pcrSlice []string) (*entities.RunResults, error) {
 		gotFn, gotInput = testReq.Function, testReq.Input
 		return &entities.RunResults{Message: []byte(results)}, nil
 	}
@@ -158,7 +158,7 @@ func TestSuccessStdin(t *testing.T) {
 	results := "success!"
 	var gotFn []byte
 	var gotInput []byte
-	test = func(testReq sdk.TestRequest, endpoint string, pcrSlice []string) (*entities.RunResults, error) {
+	test = func(testReq sdk.TestRequest, verifier sdk.Verifier, endpoint string, pcrSlice []string) (*entities.RunResults, error) {
 		gotFn, gotInput = testReq.Function, testReq.Input
 		return &entities.RunResults{Message: []byte(results)}, nil
 	}
@@ -202,7 +202,7 @@ func TestWSConnection(t *testing.T) {
 	type msg struct {
 		Message []byte `json:"msg"`
 	}
-	test = func(testReq sdk.TestRequest, endpoint string, pcrSlice []string) (*entities.RunResults, error) {
+	test = func(testReq sdk.TestRequest, verifier sdk.Verifier, endpoint string, pcrSlice []string) (*entities.RunResults, error) {
 		c, _, err := websocket.DefaultDialer.Dial(endpoint, nil)
 		if err != nil {
 			return nil, err
@@ -260,7 +260,7 @@ func TestWSConnection(t *testing.T) {
 func TestEndpoint(t *testing.T) {
 	// ensure that `cape test` hits the `/v1/test` endpoint
 	endpointHit := ""
-	test = func(testReq sdk.TestRequest, endpoint string, pcrSlice []string) (*entities.RunResults, error) {
+	test = func(testReq sdk.TestRequest, verifier sdk.Verifier, endpoint string, pcrSlice []string) (*entities.RunResults, error) {
 		endpointHit = endpoint
 		return &entities.RunResults{Message: []byte("good job")}, nil
 	}
@@ -288,7 +288,7 @@ func TestEndpoint(t *testing.T) {
 func TestEnvVarConfigEndpoint(t *testing.T) {
 	// ensure that env var overrides work for hostname
 	endpointHit := ""
-	test = func(testReq sdk.TestRequest, endpoint string, pcrSlice []string) (*entities.RunResults, error) {
+	test = func(testReq sdk.TestRequest, verifier sdk.Verifier, endpoint string, pcrSlice []string) (*entities.RunResults, error) {
 		endpointHit = endpoint
 		return &entities.RunResults{Message: []byte("good job")}, nil
 	}
@@ -322,7 +322,7 @@ func TestFileConfigEndpoint(t *testing.T) {
 	fileEndpoint := "https://foo_file.capeprivacy.com"
 	oldEndpoint := os.Getenv("CAPE_ENCLAVE_HOST")
 
-	test = func(testReq sdk.TestRequest, endpoint string, pcrSlice []string) (*entities.RunResults, error) {
+	test = func(testReq sdk.TestRequest, verifier sdk.Verifier, endpoint string, pcrSlice []string) (*entities.RunResults, error) {
 		endpointHit = endpoint
 		return &entities.RunResults{Message: []byte("good job")}, nil
 	}

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 
 require (
 	github.com/aws/aws-sdk-go v1.44.114
-	github.com/capeprivacy/attest v0.0.0-20230201194029-d22d85c6736b
+	github.com/capeprivacy/attest v0.0.0-20230306135858-d7368f33de73
 	github.com/gorilla/websocket v1.5.0
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
 	github.com/jedib0t/go-pretty/v6 v6.4.0

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ github.com/aws/aws-sdk-go v1.44.114/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX
 github.com/bwesterb/go-ristretto v1.2.1/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/capeprivacy/attest v0.0.0-20230201194029-d22d85c6736b h1:blUukiyWcEAKkK3f6myKd4GSn0ykbHgnrpG7IVtOwWQ=
 github.com/capeprivacy/attest v0.0.0-20230201194029-d22d85c6736b/go.mod h1:oqMZTaFbnXAfoncu38TnXEryQGG+8vBGJID9g/gYhi0=
+github.com/capeprivacy/attest v0.0.0-20230306135858-d7368f33de73 h1:PS/EdnIbHBtwKyRUOFGlxLbBCgZv+U4aSjY9pGLYzYo=
+github.com/capeprivacy/attest v0.0.0-20230306135858-d7368f33de73/go.mod h1:oqMZTaFbnXAfoncu38TnXEryQGG+8vBGJID9g/gYhi0=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -1,0 +1,11 @@
+package mocks
+
+import "github.com/capeprivacy/attest/attest"
+
+type MockVerifier struct {
+	VerifyFn func(attestation []byte, nonce []byte) (*attest.AttestationDoc, error)
+}
+
+func (m MockVerifier) Verify(attestation []byte, nonce []byte) (*attest.AttestationDoc, error) {
+	return m.VerifyFn(attestation, nonce)
+}

--- a/sdk/deploy.go
+++ b/sdk/deploy.go
@@ -77,14 +77,10 @@ func Deploy(req DeployRequest, keyReq KeyRequest) (string, []byte, error) {
 		return "", nil, err
 	}
 
-	log.Debug("< Downloading AWS Root Certificate")
-	rootCert, err := attest.GetRootAWSCert()
-	if err != nil {
-		return "", nil, err
-	}
+	verifier := attest.NewVerifier()
 
 	log.Debug("< Attestation document")
-	doc, err := attest.Attest(attestDoc, nonce, rootCert)
+	doc, err := verifier.Verify(attestDoc, nonce)
 	if err != nil {
 		log.Error("error attesting")
 		return "", nil, err

--- a/sdk/key.go
+++ b/sdk/key.go
@@ -109,14 +109,10 @@ func ConnectAndAttest(keyReq KeyRequest) (*attest.AttestationDoc, *AttestationUs
 		return nil, nil, err
 	}
 
-	log.Debug("< Downloading AWS Root Certificate")
-	rootCert, err := attest.GetRootAWSCert()
-	if err != nil {
-		return nil, nil, err
-	}
+	verifier := attest.NewVerifier()
 
 	log.Debug("< Auth Completed. Received Attestation Document")
-	doc, err := attest.Attest(attestDoc, nonce, rootCert)
+	doc, err := verifier.Verify(attestDoc, nonce)
 	if err != nil {
 		log.Println("error attesting")
 		return nil, nil, err

--- a/sdk/run.go
+++ b/sdk/run.go
@@ -76,14 +76,10 @@ func connect(url string, functionID string, functionAuth entities.FunctionAuth, 
 		return nil, nil, err
 	}
 
-	log.Debug("< Downloading AWS Root Certificate")
-	rootCert, err := attest.GetRootAWSCert()
-	if err != nil {
-		return nil, nil, err
-	}
+	verifier := attest.NewVerifier()
 
 	log.Debug("< Auth Completed. Received Attestation Document")
-	doc, err := attest.Attest(attestDoc, nonce, rootCert)
+	doc, err := verifier.Verify(attestDoc, nonce)
 	if err != nil {
 		log.Println("error attesting")
 		return nil, nil, err

--- a/sdk/test_test.go
+++ b/sdk/test_test.go
@@ -1,7 +1,6 @@
 package sdk
 
 import (
-	"crypto/x509"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -11,6 +10,7 @@ import (
 
 	"github.com/capeprivacy/attest/attest"
 	"github.com/capeprivacy/cli/entities"
+	"github.com/capeprivacy/cli/mocks"
 )
 
 type testProtocol struct {
@@ -45,9 +45,12 @@ func wsURL(origURL string) string {
 }
 
 func TestCapeTest(t *testing.T) {
-	runAttestation = func(attestation []byte, nonce []byte, rootCert *x509.Certificate) (*attest.AttestationDoc, error) {
-		return &attest.AttestationDoc{}, nil
+	verifier := mocks.MockVerifier{
+		VerifyFn: func(attestation []byte, nonce []byte) (*attest.AttestationDoc, error) {
+			return &attest.AttestationDoc{}, nil
+		},
 	}
+
 	localEncrypt = func(doc attest.AttestationDoc, plaintext []byte) ([]byte, error) { return plaintext, nil }
 
 	getProtocolFn = func(ws *websocket.Conn) protocol {
@@ -80,7 +83,7 @@ func TestCapeTest(t *testing.T) {
 		Insecure: true,
 	}
 
-	res, err := Test(test, wsURL(s.URL), []string{})
+	res, err := Test(test, verifier, wsURL(s.URL), []string{})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
We do this by updating to the latest attest package which let's us override the current time during verifying a certificate chain. We read the NotBefore value from the attestation document Certificate and update the current time to be NotBefore. If we don't do this then the certificate chain verification will fail because the Attestation document is only valid for 4 hours.