### PR TITLE
Removing function token support

### DIFF
--- a/cmd/cape/cmd/deploy.go
+++ b/cmd/cape/cmd/deploy.go
@@ -206,6 +206,7 @@ func doDeploy(url string, functionInput string, functionName string, insecure bo
 		Reader:    reader,
 		Insecure:  insecure,
 		PcrSlice:  pcrSlice,
+		Public:    public,
 		AuthToken: token,
 	}, keyReq)
 	if err != nil {

--- a/entities/entities.go
+++ b/entities/entities.go
@@ -28,6 +28,7 @@ type DeployRequest struct {
 
 type FunctionInfo struct {
 	FunctionName string `json:"function_name"`
+	Public       bool   `json:"public"`
 }
 
 type FunctionMetadata struct {

--- a/entities/entities.go
+++ b/entities/entities.go
@@ -8,9 +8,8 @@ import (
 type StartRequest struct {
 	// Nonce is used by the client to verify the nonce received back in
 	// the attestation doc
-	Nonce         []byte           `json:"nonce"`
-	FunctionToken string           `json:"function_token,omitempty"`
-	Metadata      FunctionMetadata `json:"metadata,omitempty"`
+	Nonce    []byte           `json:"nonce"`
+	Metadata FunctionMetadata `json:"metadata,omitempty"`
 }
 
 type RunRequest struct {
@@ -28,8 +27,7 @@ type DeployRequest struct {
 }
 
 type FunctionInfo struct {
-	FunctionTokenPublicKey string `json:"function_token_pk"`
-	FunctionName           string `json:"function_name"`
+	FunctionName string `json:"function_name"`
 }
 
 type FunctionMetadata struct {
@@ -64,7 +62,7 @@ type AuthenticationType string
 
 func (a AuthenticationType) Validate() error {
 	switch a {
-	case AuthenticationTypeUserToken, AuthenticationTypeFunctionToken:
+	case AuthenticationTypeUserToken:
 		return nil
 	default:
 		return fmt.Errorf("invalid authentication type: %s", a)
@@ -76,8 +74,7 @@ func (a AuthenticationType) String() string {
 }
 
 const (
-	AuthenticationTypeUserToken     AuthenticationType = "user_token"
-	AuthenticationTypeFunctionToken AuthenticationType = "functiontoken"
+	AuthenticationTypeUserToken AuthenticationType = "user_token"
 )
 
 type FunctionAuth struct {

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -90,8 +90,8 @@ func (p Protocol) ReadFunctionInfo() (*entities.FunctionInfo, error) {
 	return readMsg[entities.FunctionInfo](p.Websocket)
 }
 
-func (p Protocol) WriteFunctionInfo(key string, name string) error {
-	return writeMsg(p.Websocket, entities.FunctionInfo{FunctionTokenPublicKey: key, FunctionName: name})
+func (p Protocol) WriteFunctionInfo(name string) error {
+	return writeMsg(p.Websocket, entities.FunctionInfo{FunctionName: name})
 }
 
 func (p Protocol) ReadAttestationDoc() ([]byte, error) {

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -90,8 +90,8 @@ func (p Protocol) ReadFunctionInfo() (*entities.FunctionInfo, error) {
 	return readMsg[entities.FunctionInfo](p.Websocket)
 }
 
-func (p Protocol) WriteFunctionInfo(name string) error {
-	return writeMsg(p.Websocket, entities.FunctionInfo{FunctionName: name})
+func (p Protocol) WriteFunctionInfo(name string, public bool) error {
+	return writeMsg(p.Websocket, entities.FunctionInfo{FunctionName: name, Public: public})
 }
 
 func (p Protocol) ReadAttestationDoc() ([]byte, error) {

--- a/sdk/deploy.go
+++ b/sdk/deploy.go
@@ -21,7 +21,7 @@ type protocol interface {
 	ReadAttestationDoc() ([]byte, error)
 	ReadRunResults() (*entities.RunResults, error)
 	WriteBinary([]byte) error
-	WriteFunctionInfo(name string) error
+	WriteFunctionInfo(name string, public bool) error
 	ReadDeploymentResults() (*entities.SetDeploymentIDRequest, error)
 }
 
@@ -34,6 +34,7 @@ type DeployRequest struct {
 	Name      string
 	Reader    io.Reader
 	PcrSlice  []string
+	Public    bool
 	AuthToken string
 
 	// For development use only: skips validating TLS certificate from the URL
@@ -109,9 +110,9 @@ func Deploy(req DeployRequest, keyReq KeyRequest) (string, []byte, error) {
 		return "", nil, err
 	}
 
-	log.Debug("\n> Sending Public Key")
-	if err := p.WriteFunctionInfo(req.Name); err != nil {
-		log.Error("error sending public key")
+	log.Debug("\n> Sending Function Info")
+	if err := p.WriteFunctionInfo(req.Name, req.Public); err != nil {
+		log.Error("error sending function info key")
 		return "", nil, err
 	}
 

--- a/sdk/deploy.go
+++ b/sdk/deploy.go
@@ -21,7 +21,7 @@ type protocol interface {
 	ReadAttestationDoc() ([]byte, error)
 	ReadRunResults() (*entities.RunResults, error)
 	WriteBinary([]byte) error
-	WriteFunctionInfo(key string, name string) error
+	WriteFunctionInfo(name string) error
 	ReadDeploymentResults() (*entities.SetDeploymentIDRequest, error)
 }
 
@@ -30,12 +30,11 @@ func getProtocol(ws *websocket.Conn) protocol {
 }
 
 type DeployRequest struct {
-	URL                    string
-	Name                   string
-	Reader                 io.Reader
-	PcrSlice               []string
-	FunctionTokenPublicKey string
-	AuthToken              string
+	URL       string
+	Name      string
+	Reader    io.Reader
+	PcrSlice  []string
+	AuthToken string
 
 	// For development use only: skips validating TLS certificate from the URL
 	Insecure bool
@@ -111,7 +110,7 @@ func Deploy(req DeployRequest, keyReq KeyRequest) (string, []byte, error) {
 	}
 
 	log.Debug("\n> Sending Public Key")
-	if err := p.WriteFunctionInfo(req.FunctionTokenPublicKey, req.Name); err != nil {
+	if err := p.WriteFunctionInfo(req.Name); err != nil {
 		log.Error("error sending public key")
 		return "", nil, err
 	}

--- a/sdk/key.go
+++ b/sdk/key.go
@@ -75,9 +75,6 @@ func ConnectAndAttest(keyReq KeyRequest) (*attest.AttestationDoc, *AttestationUs
 
 	authProtocolType := "cape.runtime"
 	auth := keyReq.FunctionAuth
-	if auth.Type == entities.AuthenticationTypeFunctionToken {
-		authProtocolType = "cape.function"
-	}
 
 	conn, err := doDial(endpoint, keyReq.Insecure, authProtocolType, auth.Token)
 	if err != nil {

--- a/sdk/run.go
+++ b/sdk/run.go
@@ -46,9 +46,6 @@ func connect(url string, functionID string, functionAuth entities.FunctionAuth, 
 
 	authProtocolType := "cape.runtime"
 	auth := functionAuth
-	if auth.Type == entities.AuthenticationTypeFunctionToken {
-		authProtocolType = "cape.function"
-	}
 
 	conn, err := doDial(endpoint, insecure, authProtocolType, auth.Token)
 	if err != nil {

--- a/sdk/test_test.go
+++ b/sdk/test_test.go
@@ -20,7 +20,7 @@ type testProtocol struct {
 	binary  func(b []byte) error
 }
 
-func (t testProtocol) WriteFunctionInfo(name string) error {
+func (t testProtocol) WriteFunctionInfo(name string, public bool) error {
 	return nil
 }
 

--- a/sdk/test_test.go
+++ b/sdk/test_test.go
@@ -20,7 +20,7 @@ type testProtocol struct {
 	binary  func(b []byte) error
 }
 
-func (t testProtocol) WriteFunctionInfo(key string, name string) error {
+func (t testProtocol) WriteFunctionInfo(name string) error {
 	return nil
 }
 


### PR DESCRIPTION
Looking at the Prometheus metric `function_token_authorization` function tokens are no longer being used. 