### PR TITLE
Use configured repo secret instead of default action token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,5 +40,5 @@ jobs:
           version: latest
           args: release --rm-dist
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           SSH_AUTH_SOCK: /tmp/ssh_agent.sock


### PR DESCRIPTION
Switches the goreleaser workflow to use a secret configured on the
repository instead of the token generated by GitHub for the action
invocation. This is necessary in order to grant access to the homebrew
repository.
