### PR TITLE
Refactor login to use golang.org/x/oauth2

### DIFF
--- a/cape.go
+++ b/cape.go
@@ -1,6 +1,14 @@
 package cli
 
-import "github.com/capeprivacy/attest/attest"
+import (
+	"encoding/json"
+	"io"
+	"os"
+
+	"golang.org/x/oauth2"
+
+	"github.com/capeprivacy/attest/attest"
+)
 
 type Checksums struct {
 	Input    []byte `json:"input"`
@@ -16,4 +24,33 @@ type RunResult struct {
 
 	DecodedAttestationDocument *attest.AttestationDoc `json:"decoded_attestation_document"`
 	RawAttestationDocument     []byte                 `json:"raw_attestation_document"`
+}
+
+func TokenFromFile(path string) (*oauth2.Token, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	return TokenFromReader(f)
+}
+
+func TokenFromReader(r io.Reader) (*oauth2.Token, error) {
+	bytes, err := io.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+
+	var tok *oauth2.Token
+	if err := json.Unmarshal(bytes, &tok); err != nil {
+		return nil, err
+	}
+
+	var raw map[string]interface{}
+	if err := json.Unmarshal(bytes, &raw); err != nil {
+		return nil, err
+	}
+
+	return tok.WithExtra(raw), nil
 }

--- a/cmd/cape/cmd/deploy.go
+++ b/cmd/cape/cmd/deploy.go
@@ -9,6 +9,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/capeprivacy/cli"
 	"github.com/capeprivacy/cli/render"
 	"github.com/capeprivacy/cli/sdk"
 )
@@ -156,18 +157,18 @@ func getUsername(t string) (string, error) {
 }
 
 func getAuthToken() (string, error) {
-	tokenResponse, err := getTokenResponse()
+	tok, err := cli.TokenFromFile(filepath.Join(C.LocalConfigDir, C.LocalAuthFileName))
 	if err != nil {
 		return "", fmt.Errorf("failed to get auth token (did you run 'cape login'?): %v", err)
 	}
 
-	if tokenResponse.AccessToken == "" {
+	if tok.AccessToken == "" {
 		return "", fmt.Errorf("empty access token (did you run 'cape login'?)")
 	}
 
 	log.Debug("* Retrieved Auth Token")
 
-	return tokenResponse.AccessToken, nil
+	return tok.AccessToken, nil
 }
 
 var deployTmpl = `Function ID       ➜  {{ .ID }}

--- a/cmd/cape/cmd/encrypt.go
+++ b/cmd/cape/cmd/encrypt.go
@@ -6,11 +6,13 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/lestrrat-go/jwx/v2/jwt"
 	"github.com/spf13/cobra"
 
+	"github.com/capeprivacy/cli"
 	"github.com/capeprivacy/cli/sdk"
 )
 
@@ -49,13 +51,19 @@ func encrypt(cmd *cobra.Command, args []string) error {
 	}
 
 	if username == "" {
-		t, err := getTokenResponse()
+		t, err := cli.TokenFromFile(filepath.Join(C.LocalConfigDir, C.LocalAuthFileName))
 		if err != nil {
 			cmd.SilenceUsage = true
 			return fmt.Errorf("couldn't get username from ~/.config/cape/auth id token, are you logged in? (run `cape login`)")
 		}
 
-		j, err := jwt.ParseInsecure([]byte(t.IDToken))
+		idTok, ok := t.Extra("id_token").(string)
+		if !ok {
+			cmd.SilenceUsage = true
+			return fmt.Errorf("couldn't get username from ~/.config/cape/auth id token, are you logged in? (run `cape login`)")
+		}
+
+		j, err := jwt.ParseInsecure([]byte(idTok))
 		if err != nil {
 			cmd.SilenceUsage = true
 			return fmt.Errorf("couldn't get username from ~/.config/cape/auth id token, are you logged in? (run `cape login`)")

--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,13 @@ module github.com/capeprivacy/cli
 go 1.20
 
 require (
-	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/cloudflare/circl v1.3.2
 	github.com/hashicorp/go-version v1.6.0
 	github.com/lestrrat-go/jwx/v2 v2.0.8
 	github.com/lithammer/shortuuid/v4 v4.0.0
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.6.1
+	golang.org/x/oauth2 v0.0.0-20221014153046-6fdb5e3db783
 	golang.org/x/text v0.8.0
 )
 
@@ -18,6 +18,7 @@ require (
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.4.0 // indirect
 	github.com/goccy/go-json v0.10.0 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hf/nsm v0.0.0-20220930140112-cd181bd646b9 // indirect
@@ -37,7 +38,10 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/subosito/gotenv v1.4.2 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
+	golang.org/x/net v0.8.0 // indirect
 	golang.org/x/sys v0.7.0 // indirect
+	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
@@ -51,7 +55,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jedib0t/go-pretty/v6 v6.4.6
 	github.com/sirupsen/logrus v1.9.0
-	github.com/spf13/pflag v1.0.5
+	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.15.0
 	github.com/veraison/go-cose v1.0.0 // indirect
 	golang.org/x/crypto v0.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,6 @@ cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3f
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
-github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/aws/aws-sdk-go v1.44.214 h1:YzDuC+9UtrAOUkItlK7l3BvKI9o6qAog9X8i289HORc=
 github.com/aws/aws-sdk-go v1.44.214/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/capeprivacy/attest v0.0.0-20230306135858-d7368f33de73 h1:PS/EdnIbHBtwKyRUOFGlxLbBCgZv+U4aSjY9pGLYzYo=
@@ -104,6 +102,9 @@ github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvq
 github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QDs8UjoX8=
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
+github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
+github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
+github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
@@ -115,6 +116,7 @@ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
@@ -328,6 +330,7 @@ golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.1.0/go.mod h1:Cx3nUiGt4eDBEyega/BKRp+/AlGL8hYe7U9odMt2Cco=
 golang.org/x/net v0.8.0 h1:Zrh2ngAOFYneWTAIAPethzeaQLuHwhuBkuV6ZiRnUaQ=
+golang.org/x/net v0.8.0/go.mod h1:QVkue5JL9kW//ek3r6jTKnTFis1tRmNAW2P1shuFdJc=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -337,6 +340,8 @@ golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43/go.mod h1:KelEdhl1UZF7XfJ
 golang.org/x/oauth2 v0.0.0-20201109201403-9fd604954f58/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20201208152858-08078c50e5b5/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
+golang.org/x/oauth2 v0.0.0-20221014153046-6fdb5e3db783 h1:nt+Q6cXKz4MosCSpnbMtqiQ8Oz0pxTef2B4Vca2lvfk=
+golang.org/x/oauth2 v0.0.0-20221014153046-6fdb5e3db783/go.mod h1:h4gKUeWbJ4rQPri7E0u6Gs4e9Ri2zaLxzw5DI5XGrYg=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -485,6 +490,7 @@ google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7
 google.golang.org/appengine v1.6.1/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/appengine v1.6.6/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
+google.golang.org/appengine v1.6.7 h1:FZR1q0exgwxzPzp/aF+VccGrSfxfPpkBqjIIEq3ru6c=
 google.golang.org/appengine v1.6.7/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
@@ -548,6 +554,10 @@ google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2
 google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
+google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
+google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=
+google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=

--- a/oauth2device/oauth2device.go
+++ b/oauth2device/oauth2device.go
@@ -1,0 +1,160 @@
+package oauth2device
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+// A DeviceAuthorizationResponse is returned by the server in response to
+// device authorization request. See
+// https://www.rfc-editor.org/rfc/rfc8628#section-3.2
+type DeviceCode struct {
+	DeviceCode              string `json:"device_code"`
+	UserCode                string `json:"user_code"`
+	VerificationURI         string `json:"verification_uri"`
+	VerificationURIComplete string `json:"verification_uri_complete"`
+	ExpiresIn               int64  `json:"expires_in"`
+	Interval                int64  `json:"interval"`
+}
+
+// An AuthorizationError is the response sent by authorization server. See
+// https://www.rfc-editor.org/rfc/rfc6749#section-5.2
+type AuthorizationError struct {
+	Err         string `json:"error"`
+	Description string `json:"error_description"`
+	URI         string `json:"error_uri"`
+}
+
+// Error implements error
+func (e AuthorizationError) Error() string {
+	if e.Description == "" && e.URI == "" {
+		return e.Err
+	}
+
+	if e.URI == "" {
+		return fmt.Sprintf("%s: %s", e.Err, e.Description)
+	}
+
+	return fmt.Sprintf("%s: %s (see %s)", e.Err, e.Description, e.URI)
+}
+
+// Endpoint contains the URLs required to initiate the OAuth2.0 flow for a
+// provider's device flow.
+type Endpoint struct {
+	CodeURL string
+}
+
+// A Config is an oauth2.Config with an endpoint for the device flow
+type Config struct {
+	*oauth2.Config
+	DeviceEndpoint Endpoint
+	Audience       string
+}
+
+var (
+	ErrFetchDeviceCode   = errors.New("error fetching device code")
+	ErrInvalidDeviceCode = errors.New("invalid device code")
+	ErrFetchToken        = errors.New("error fetching token")
+	ErrAccessDenied      = errors.New("access denied by user")
+)
+
+const (
+	deviceGrantType = "urn:ietf:params:oauth:grant-type:device_code"
+)
+
+// contextClient returns the oauth2 HTTP client from the context, or the
+// default client if one is not present.
+func contextClient(ctx context.Context) *http.Client {
+	if ctx != nil {
+		if hc, ok := ctx.Value(oauth2.HTTPClient).(*http.Client); ok {
+			return hc
+		}
+	}
+	return http.DefaultClient
+}
+
+// RequestDeviceCode will initiate the OAuth2 device authorization flow. It
+// requests a device code and information on the code and URL to show to the
+// user. Pass the returned DeviceCode to WaitForDeviceAuthorization.
+func (c *Config) DeviceCode(ctx context.Context) (*DeviceCode, error) {
+	scopes := strings.Join(c.Scopes, " ")
+	resp, err := contextClient(ctx).PostForm(
+		c.DeviceEndpoint.CodeURL,
+		url.Values{
+			"client_id": {c.ClientID},
+			"scope":     {scopes},
+			"audience":  {c.Audience},
+		},
+	)
+	if err != nil {
+		return nil, ErrFetchDeviceCode
+	}
+
+	var dc struct {
+		*DeviceCode
+		*AuthorizationError
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&dc); err != nil {
+		return nil, ErrInvalidDeviceCode
+	}
+
+	if dc.AuthorizationError != nil {
+		return nil, *dc.AuthorizationError
+	}
+
+	return dc.DeviceCode, nil
+}
+
+// Wait polls the token URL waiting for the user to
+// authorize the app. Upon authorization, it returns the new token. If
+// authorization fails then an error is returned. If that failure was due to a
+// user explicitly denying access, the error is ErrAccessDenied.
+func (c *Config) Wait(ctx context.Context, code *DeviceCode) (*oauth2.Token, error) {
+	for {
+		resp, err := contextClient(ctx).PostForm(c.Endpoint.TokenURL,
+			url.Values{
+				"client_secret": {c.ClientSecret},
+				"client_id":     {c.ClientID},
+				"device_code":   {code.DeviceCode},
+				"grant_type":    {deviceGrantType}})
+		if err != nil {
+			return nil, err
+		}
+
+		var tok struct {
+			*oauth2.Token
+			IDToken string `json:"id_token,omitempty"`
+			*AuthorizationError
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&tok); err != nil {
+			return nil, ErrFetchToken
+		}
+
+		if tok.AuthorizationError == nil {
+			return tok.Token.WithExtra(map[string]interface{}{
+				"id_token": tok.IDToken,
+			}), nil
+		}
+
+		switch tok.AuthorizationError.Err {
+		case "authorization_pending":
+			// do nothing; wait for user to authorize
+		case "slow_down":
+			code.Interval *= 2
+		case "access_denied":
+			return nil, ErrAccessDenied
+		default:
+			return nil, fmt.Errorf("authorization failed: %s", tok.Error())
+		}
+
+		time.Sleep(time.Duration(code.Interval) * time.Second)
+	}
+}

--- a/oauth2device/oauth2device_test.go
+++ b/oauth2device/oauth2device_test.go
@@ -1,0 +1,274 @@
+package oauth2device
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"testing"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+func TestAuthorizationError(t *testing.T) {
+	tests := []struct {
+		name string
+		in   AuthorizationError
+		out  string
+	}{
+		{
+			name: "only error provided",
+			in:   AuthorizationError{Err: "foo"},
+			out:  "foo",
+		},
+		{
+			name: "error and description provided",
+			in: AuthorizationError{
+				Err:         "foo",
+				Description: "bar",
+			},
+			out: "foo: bar",
+		},
+		{
+			name: "all fields provided",
+			in: AuthorizationError{
+				Err:         "foo",
+				Description: "bar",
+				URI:         "baz",
+			},
+			out: "foo: bar (see baz)",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got, want := test.in.Error(), test.out; got != want {
+				t.Errorf("incorrect string; got %q want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestContextClient(t *testing.T) {
+	tests := []struct {
+		name   string
+		ctx    context.Context
+		client *http.Client
+	}{
+		{
+			name:   "nil context returns default client",
+			ctx:    nil,
+			client: http.DefaultClient,
+		},
+		{
+			name:   "context with no client returns default client",
+			ctx:    context.Background(),
+			client: http.DefaultClient,
+		},
+		{
+			name:   "context with client returns client",
+			ctx:    context.WithValue(context.Background(), oauth2.HTTPClient, &http.Client{Timeout: 20 * time.Minute}),
+			client: &http.Client{Timeout: 20 * time.Minute},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got, want := contextClient(test.ctx), test.client; !reflect.DeepEqual(got, want) {
+				t.Errorf("incorrect client returned; got %#v want %#v", got, want)
+			}
+		})
+	}
+}
+
+func TestDeviceCode(t *testing.T) {
+	tests := []struct {
+		name string
+		ctx  context.Context
+		h    http.Handler
+		dc   *DeviceCode
+		err  error
+	}{
+		{
+			name: "error fetching device code",
+			ctx:  context.WithValue(context.Background(), oauth2.HTTPClient, errorClient),
+			h:    http.NotFoundHandler(),
+			dc:   nil,
+			err:  ErrFetchDeviceCode,
+		},
+		{
+			name: "http error fetching device code",
+			ctx:  context.Background(),
+			h:    http.NotFoundHandler(),
+			dc:   nil,
+			err:  ErrInvalidDeviceCode,
+		},
+		{
+			name: "invalid device code returned",
+			ctx:  context.Background(),
+			h:    staticHandler(`{"device_code":42,"user_code":"bar"}`),
+			dc:   nil,
+			err:  ErrInvalidDeviceCode,
+		},
+		{
+			name: "valid device code",
+			ctx:  context.Background(),
+			h:    staticHandler(`{"device_code":"foo","user_code":"bar"}`),
+			dc: &DeviceCode{
+				DeviceCode: "foo",
+				UserCode:   "bar",
+			},
+			err: nil,
+		},
+		{
+			name: "authorization error",
+			ctx:  context.Background(),
+			h:    staticHandler(`{"error":"foo"}`),
+			dc:   nil,
+			err:  AuthorizationError{Err: "foo"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ts := httptest.NewServer(test.h)
+			defer ts.Close()
+
+			c := &Config{
+				Config:         &oauth2.Config{},
+				DeviceEndpoint: Endpoint{CodeURL: ts.URL},
+			}
+
+			dc, err := c.DeviceCode(test.ctx)
+
+			if got, want := dc, test.dc; !reflect.DeepEqual(got, want) {
+				t.Errorf("incorrect device code; got %#v want %#v", got, want)
+			}
+
+			if got, want := err, test.err; !reflect.DeepEqual(got, want) {
+				t.Errorf("incorrect error; got %#v want %#v", got, want)
+			}
+		})
+	}
+}
+
+func TestWaitHttpError(t *testing.T) {
+	c := Config{
+		Config: &oauth2.Config{
+			Endpoint: oauth2.Endpoint{TokenURL: "this://is\nwrong"},
+		},
+	}
+	_, err := c.Wait(context.Background(), new(DeviceCode))
+	urlErr := &url.Error{Op: "parse", URL: "this://is\nwrong", Err: errors.New("net/url: invalid control character in URL")}
+	if got, want := err, urlErr; !reflect.DeepEqual(got, want) {
+		t.Errorf("incorrect error;\n\t got %q\n\twant %q", got.Error(), want.Error())
+	}
+}
+
+func TestWait(t *testing.T) {
+	tests := []struct {
+		name  string
+		resps []string
+		tok   *oauth2.Token
+		err   error
+	}{
+		{
+			name:  "invalid json response",
+			resps: []string{`this{\nisn't good`},
+			tok:   nil,
+			err:   ErrFetchToken,
+		},
+		{
+			name:  "valid token",
+			resps: []string{`{"access_token":"foo","id_token":"bar"}`},
+			tok: (&oauth2.Token{AccessToken: "foo"}).WithExtra(
+				map[string]interface{}{"id_token": "bar"},
+			),
+			err: nil,
+		},
+		{
+			name: "authorization pending",
+			resps: []string{
+				`{"error":"authorization_pending"}`,
+				`{"access_token":"foo","id_token":"bar"}`,
+			},
+			tok: (&oauth2.Token{AccessToken: "foo"}).WithExtra(
+				map[string]interface{}{"id_token": "bar"},
+			),
+			err: nil,
+		},
+		{
+			name: "slow down",
+			resps: []string{
+				`{"error":"slow_down"}`,
+				`{"access_token":"foo","id_token":"bar"}`,
+			},
+			tok: (&oauth2.Token{AccessToken: "foo"}).WithExtra(
+				map[string]interface{}{"id_token": "bar"},
+			),
+			err: nil,
+		},
+		{
+			name:  "access denied",
+			resps: []string{`{"error":"access_denied"}`},
+			tok:   nil,
+			err:   ErrAccessDenied,
+		},
+		{
+			name:  "other error",
+			resps: []string{`{"error":"what in the!?"}`},
+			tok:   nil,
+			err:   errors.New("authorization failed: what in the!?"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var count int
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprint(w, test.resps[count])
+				count++
+			}))
+			defer srv.Close()
+
+			c := Config{
+				Config: &oauth2.Config{
+					Endpoint: oauth2.Endpoint{TokenURL: srv.URL},
+				},
+			}
+
+			tok, err := c.Wait(context.Background(), new(DeviceCode))
+			if got, want := err, test.err; !reflect.DeepEqual(got, want) {
+				t.Errorf("incorrect error;\n\t got %q\n\twant %q", got.Error(), want.Error())
+				t.Logf("err: %#v", got)
+			}
+
+			if got, want := tok, test.tok; !reflect.DeepEqual(got, want) {
+				t.Errorf("incorrect token;\n\t got %#v\n\twant %#v", got, want)
+			}
+		})
+	}
+}
+
+type errorRoundTripper struct{}
+
+func (e errorRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, errors.New("nope")
+}
+
+var errorClient = &http.Client{Transport: errorRoundTripper{}}
+
+func staticHandler(s string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, s)
+	})
+}
+
+/*
+func (c *Config) DeviceCode(ctx context.Context) (*DeviceCode, error) {
+func (c *Config) Wait(ctx context.Context, code *DeviceCode) (*oauth2.Token, error) {
+*/

--- a/oauth2device/oauth2device_test.go
+++ b/oauth2device/oauth2device_test.go
@@ -267,8 +267,3 @@ func staticHandler(s string) http.Handler {
 		fmt.Fprint(w, s)
 	})
 }
-
-/*
-func (c *Config) DeviceCode(ctx context.Context) (*DeviceCode, error) {
-func (c *Config) Wait(ctx context.Context, code *DeviceCode) (*oauth2.Token, error) {
-*/


### PR DESCRIPTION
Refactors the login process to use the defacto standard golang oauth2
library. Add an oauth2device package to support the device code flow.
This does not yet update the consumers of the returned token.
