### PR TITLE
support zip input for test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,19 +11,19 @@ jobs:
     name: Build & Test
     runs-on: ubuntu-latest
     steps:
-    - name: Setup go1.19 Environment
+    - name: Setup go1.20 Environment
       uses: actions/setup-go@v3
       with:
-        go-version: '1.19.3'
+        go-version: '1.20.2'
       id: go
     - id: go-cache-paths
       run: |
         echo "::set-output name=go-build::$(go env GOCACHE)"
         echo "::set-output name=go-mod::$(go env GOMODCACHE)"
     - name: Check out repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Go dependencies cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ${{ steps.go-cache-paths.outputs.go-build }}
@@ -39,12 +39,12 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
-          go-version: '1.19.3'
-      - uses: actions/checkout@v2
+          go-version: '1.20.2'
+      - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.50.1
+          version: v1.51.2
           args: --timeout=3m0s --verbose

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,15 +14,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Fetch all tags
         run: git fetch --force --tags
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.20
       - name: Setup SSH Keys and known_hosts
         env:
           SSH_AUTH_SOCK: /tmp/ssh_agent.sock

--- a/cmd/cape/cmd/test.go
+++ b/cmd/cape/cmd/test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/capeprivacy/attest/attest"
 	"github.com/capeprivacy/cli/sdk"
-	czip "github.com/capeprivacy/cli/zip"
 )
 
 var testCmd = &cobra.Command{
@@ -56,11 +55,15 @@ func Test(cmd *cobra.Command, args []string) error {
 		return UserError{Msg: "you must provide input data", Err: fmt.Errorf("invalid number of input arguments")}
 	}
 
-	fnZip, err := czip.Create(args[0])
+	userFunc, err := sdk.ProcessUserFunction(args[0])
 	if err != nil {
-		return UserError{Msg: "unable to zip specified directory", Err: err}
+		return UserError{Msg: "unable to process user function input", Err: err}
 	}
 
+	fnZip, err := io.ReadAll(userFunc)
+	if err != nil {
+		return UserError{Msg: "unable to read user function input", Err: err}
+	}
 	var input []byte
 	file, err := cmd.Flags().GetString("file")
 	if err != nil {

--- a/cmd/cape/cmd/test_test.go
+++ b/cmd/cape/cmd/test_test.go
@@ -70,7 +70,7 @@ func TestBadFunction(t *testing.T) {
 		t.Fatal(errors.New("received no error when we should have"))
 	}
 
-	if got, want := stderr.String(), "Error: unable to zip specified directory: zipping directory failed: lstat notafunction: no such file or directory\n"; got != want {
+	if got, want := stderr.String(), "Error: unable to process user function input: unable to read function directory or file: open testdata/notafunction: no such file or directory\n"; got != want {
 		t.Errorf("didn't get expected stderr, got %s, wanted %s", got, want)
 	}
 

--- a/sdk/deploy.go
+++ b/sdk/deploy.go
@@ -1,10 +1,13 @@
 package sdk
 
 import (
+	"archive/zip"
 	"bytes"
 	"crypto/sha256"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 
 	"github.com/gorilla/websocket"
 	log "github.com/sirupsen/logrus"
@@ -16,7 +19,18 @@ import (
 	"github.com/capeprivacy/cli/entities"
 	"github.com/capeprivacy/cli/pcrs"
 	proto "github.com/capeprivacy/cli/protocol"
+	czip "github.com/capeprivacy/cli/zip"
 )
+
+const storedFunctionMaxBytes = 1_000_000_000
+
+type OversizeFunctionError struct {
+	bytes int64
+}
+
+func (e OversizeFunctionError) Error() string {
+	return fmt.Sprintf("deployment (%d bytes) exceeds size limit of %d bytes", e.bytes, storedFunctionMaxBytes)
+}
 
 type protocol interface {
 	WriteStart(request entities.StartRequest) error
@@ -149,4 +163,99 @@ func writeFunction(conn *websocket.Conn, reader io.Reader) error {
 	}
 
 	return nil
+}
+
+// ProcessUserFunction takes a string path and produces a io.Reader to zipped function.
+// It could take both a folder as well as a zip file.
+func ProcessUserFunction(path string) (io.Reader, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read function directory or file: %w", err)
+	}
+
+	st, err := file.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("unable to read function file or directory: %w", err)
+	}
+
+	isZip := false
+	var fileSize int64
+	if st.IsDir() {
+		_, err = file.Readdirnames(1)
+		if err != nil {
+			return nil, fmt.Errorf("please pass in a non-empty directory: %w", err)
+		}
+		fileSize, err = dirSize(path)
+		if err != nil {
+			return nil, fmt.Errorf("error reading file size: %w", err)
+		}
+	} else {
+		// Check if file ends with ".zip" extension.
+		fileExtension := filepath.Ext(path)
+		if fileExtension != ".zip" {
+			return nil, fmt.Errorf("expected argument %s to be a zip file or directory", path)
+		}
+		isZip = true
+		zSize, err := zipSize(path)
+		if err != nil {
+			return nil, err
+		}
+
+		fileSize = int64(zSize)
+	}
+
+	log.Debugf("Deployment size: %d bytes", fileSize)
+	if fileSize > storedFunctionMaxBytes {
+		err = OversizeFunctionError{bytes: fileSize}
+		log.Error(err.Error())
+		return nil, err
+	}
+
+	err = file.Close()
+	if err != nil {
+		return nil, fmt.Errorf("something went wrong: %w", err)
+	}
+
+	var reader io.Reader
+
+	if isZip {
+		f, err := os.Open(path)
+		if err != nil {
+			return nil, fmt.Errorf("unable to read function file: %w", err)
+		}
+
+		reader = f
+	} else {
+		buf, err := czip.Create(path)
+		if err != nil {
+			return nil, err
+		}
+
+		reader = bytes.NewBuffer(buf)
+	}
+	return reader, nil
+}
+
+func zipSize(path string) (uint64, error) {
+	var size uint64
+	r, err := zip.OpenReader(path)
+	if err != nil {
+		return 0, err
+	}
+	for _, f := range r.File {
+		size += f.UncompressedSize64
+	}
+
+	return size, nil
+}
+
+func dirSize(path string) (int64, error) {
+	var size int64
+	err := filepath.Walk(path, func(_ string, info os.FileInfo, err error) error {
+		if !info.IsDir() {
+			size += info.Size()
+		}
+		return nil
+	})
+	return size, err
 }


### PR DESCRIPTION
refactor test to support zip input, this is so that we can re-use the zip file in our own internal tests. 