### PR TITLE
Use generic status error for unexpected http errors

### DIFF
--- a/cmd/cape/cmd/delete.go
+++ b/cmd/cape/cmd/delete.go
@@ -83,14 +83,14 @@ func doDelete(url string, functionID string, insecure bool, auth entities.Functi
 
 		var errMsg ErrorMsg
 		if err := json.NewDecoder(res.Body).Decode(&errMsg); err != nil {
-			return fmt.Errorf("expected 200, got server response code %d and could not decode err msg", res.StatusCode)
+			return httpError(res.StatusCode)
 		}
 
 		if errMsg.Error() != "" {
 			return errMsg
 		}
 
-		return fmt.Errorf("expected 200, got server response code %d", res.StatusCode)
+		return httpError(res.StatusCode)
 	}
 
 	log.Infof("Success! Function %s deleted.\n", functionID)

--- a/cmd/cape/cmd/delete_test.go
+++ b/cmd/cape/cmd/delete_test.go
@@ -52,7 +52,7 @@ func TestDeleteBadFunction(t *testing.T) {
 		t.Fatal(errors.New("received no error when we should have"))
 	}
 
-	if got, want := stderr.String(), "Error: delete failed: expected 200, got server response code 401\n"; got != want {
+	if got, want := stderr.String(), "Error: delete failed: 401 Unauthorized\n"; got != want {
 		t.Errorf("didn't get expected stderr, got %s, wanted %s", got, want)
 	}
 }

--- a/cmd/cape/cmd/error.go
+++ b/cmd/cape/cmd/error.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+type ErrorMsg struct {
+	ErrorMsg string `json:"error"`
+}
+
+func (e ErrorMsg) Error() string {
+	return e.ErrorMsg
+}
+
+var ErrUnauthorized = errors.New("unauthorized: authentication required")
+
+// httpError returns a generic error for the given http status code
+func httpError(status int) error {
+	return fmt.Errorf("%d %s", status, http.StatusText(status))
+}

--- a/cmd/cape/cmd/list.go
+++ b/cmd/cape/cmd/list.go
@@ -15,25 +15,6 @@ import (
 	"github.com/capeprivacy/cli/entities"
 )
 
-type ErrorMsg struct {
-	ErrorMsg string `json:"error"`
-}
-
-func (e ErrorMsg) Error() string {
-	return e.ErrorMsg
-}
-
-type ErrServerForList struct {
-	statusCode int
-	message    string
-}
-
-func (e ErrServerForList) Error() string {
-	return fmt.Sprintf("expected 200, got server response code when listing functions %d: %s", e.statusCode, e.message)
-}
-
-var ErrUnauthorized = errors.New("unauthorized: authentication required")
-
 // listCmd represents the list command
 var listCmd = &cobra.Command{
 	Use:   "list",
@@ -119,7 +100,7 @@ func doList(url string, insecure bool, auth entities.FunctionAuth, limit int, of
 	if res.StatusCode != 200 {
 		var e ErrorMsg
 		if err := json.NewDecoder(res.Body).Decode(&e); err != nil {
-			return ErrServerForList{statusCode: res.StatusCode}
+			return httpError(res.StatusCode)
 		}
 		res.Body.Close()
 
@@ -127,7 +108,7 @@ func doList(url string, insecure bool, auth entities.FunctionAuth, limit int, of
 			return ErrUnauthorized
 		}
 
-		return ErrServerForList{res.StatusCode, e.ErrorMsg}
+		return e
 	}
 
 	body, err := io.ReadAll(res.Body)

--- a/cmd/cape/cmd/token.go
+++ b/cmd/cape/cmd/token.go
@@ -334,9 +334,8 @@ func doGet(functionID string, url string, insecure bool, auth entities.FunctionA
 		return UserError{Msg: "function not found", Err: errors.New(functionID)}
 	case http.StatusUnauthorized:
 		return UserError{Msg: "unauthorized to create a function token for function", Err: errors.New(functionID)}
-
 	default:
-		return fmt.Errorf("expected 200, got server response code %d", res.StatusCode)
+		return httpError(res.StatusCode)
 	}
 
 	var deployment entities.Deployment

--- a/cmd/cape/cmd/token_test.go
+++ b/cmd/cape/cmd/token_test.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -85,7 +84,7 @@ func TestDoGet(t *testing.T) {
 				Location:            "",
 				AttestationDocument: nil,
 			},
-			fmt.Errorf("expected 200, got server response code %d", http.StatusConflict),
+			httpError(http.StatusConflict),
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Removes the text about expected error code in favor of a more generic
http status error. Also pulls shared error-related code into a separate
file.
